### PR TITLE
Syntax Refactor

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
   "predef": [
     "TABLE", "RAW", "STACKED", "INDEX",
     "X", "Y", "ROW", "COL", "SIZE", "SHAPE", "COLOR", "ALPHA", "TEXT", "DETAIL",
-    "O", "Q", "T"],
+    "O", "Q", "T", "N"],
   "globalstrict": true
 }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use Vega-lite in the [online editor](https://uwdata.github.io/vega-lite/).
 If you are using Vega-lite for your project(s), please let us know by emailing us at [Vega-lite \[at\] cs.washington.edu](mailto:vega-lite@cs.washington.edu).  Feedbacks are also welcomed.
 If you find a bug or have a feature request, please [create an issue](https://github.com/uwdata/vega-lite/issues/new).
 
-The complete schema for specifications as [JSON schema](http://json-schema.org/) is at [spec.json](https://uwdata.github.io/vega-lite/spec.json). 
+The complete schema for specifications as [JSON schema](http://json-schema.org/) is at [spec.json](https://uwdata.github.io/vega-lite/spec.json).
 
 ## Example specification
 
@@ -21,10 +21,10 @@ The complete schema for specifications as [JSON schema](http://json-schema.org/)
 {
   "data": {"url": "data/barley.json"},
   "marktype": "point",
-  "enc": {
-    "x": {"type": "Q","name": "yield","aggr": "avg"},
+  "encoding": {
+    "x": {"type": "Q","name": "yield","aggregate": "avg"},
     "y": {
-      "sort": [{"name": "yield","aggr": "avg","reverse": false}],
+      "sort": [{"name": "yield","aggregate": "avg","reverse": false}],
       "type": "O",
       "name": "variety"
     },
@@ -48,7 +48,7 @@ This is a similar chart as one of the Vega examples in https://github.com/trifac
     ]
   },
   "marktype": "bar",
-  "enc": {
+  "encoding": {
     "y": {"type": "Q","name": "y"},
     "x": {"type": "O","name": "x"}
   }
@@ -81,7 +81,7 @@ If you plan to make changes to datalib and test Vega-lite without publishing / c
 
 ```
 # first link datalib global npm
-cd path/to/datalib 
+cd path/to/datalib
 npm link
 # then link vega-lite to datalib
 cd path/to/vega-lite

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -75,7 +75,7 @@ vled.format = function() {
 };
 
 vled.parse = function() {
-  var spec, encoding, source;
+  var spec, encoding;
   try {
     spec = JSON.parse(d3.select("#vlspec").property("value"));
   } catch (e) {
@@ -201,7 +201,7 @@ vled.init = function() {
   } else {
     document.getElementById("vlspec").value = JSON.stringify({
       marktype: "point",
-      enc: {
+      encoding: {
         x: {type: "Q",name: "yield",aggr: "avg"},
         y: {
           sort: [{name: "yield", aggr: "avg", reverse: false}],

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -9,22 +9,13 @@ var consts = require('./consts'),
   schema = require('./schema/schema');
 
 module.exports = (function() {
-  function Encoding(marktype, enc, data, config, filter, theme) {
-    var defaults = schema.instantiate();
-
-    var spec = {
-      data: data,
-      marktype: marktype,
-      enc: enc,
-      config: config,
-      filter: filter || []
-    };
-
-    var specExtended = schema.util.merge(defaults, theme || {}, spec) ;
+  function Encoding(spec, theme) {
+    var defaults = schema.instantiate(),
+      specExtended = schema.util.merge(defaults, theme || {}, spec) ;
 
     this._data = specExtended.data;
     this._marktype = specExtended.marktype;
-    this._enc = specExtended.enc;
+    this._enc = specExtended.encoding;
     this._config = specExtended.config;
     this._filter = specExtended.filter;
   }
@@ -37,11 +28,17 @@ module.exports = (function() {
         marktype = split.shift().split(c.assign)[1].trim(),
         enc = vlenc.fromShorthand(split);
 
-    return new Encoding(marktype, enc, data, config, null, theme);
+    return new Encoding({
+      data: data,
+      marktype: marktype,
+      encoding: enc,
+      config: config,
+      filter: []
+    }, theme);
   };
 
   Encoding.fromSpec = function(spec, theme) {
-    return new Encoding(spec.marktype, spec.enc, spec.data, spec.config, spec.filter, theme);
+    return new Encoding(spec, theme);
   };
 
   proto.toShorthand = function() {
@@ -66,7 +63,7 @@ module.exports = (function() {
 
     spec = {
       marktype: this._marktype,
-      enc: enc,
+      encoding: enc,
       filter: this._filter
     };
 
@@ -82,7 +79,6 @@ module.exports = (function() {
     var defaults = schema.instantiate();
     return schema.util.subtract(spec, defaults);
   };
-
 
 
   proto.marktype = function() {
@@ -222,6 +218,7 @@ module.exports = (function() {
       isType = vlfield.isType;
 
     if ((!sort || sort.length===0) &&
+        // FIXME
         Encoding.toggleSort.support({enc:this._enc}, stats, true) && //HACK
         this.config('toggleSort') === Q
       ) {

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -169,7 +169,7 @@ module.exports = (function() {
 
     if ((!sort || sort.length===0) &&
         Encoding.toggleSort.support({enc:this._enc}, stats, true) && //HACK
-        this.config('toggleSort') === 'Q'
+        this.config('toggleSort') === Q
       ) {
       var qField = isType(enc.x, O) ? enc.y : enc.x;
 
@@ -362,7 +362,7 @@ module.exports = (function() {
 
   Encoding.toggleSort = function(spec) {
     spec.config = spec.config || {};
-    spec.config.toggleSort = spec.config.toggleSort === 'Q' ? 'O' :'Q';
+    spec.config.toggleSort = spec.config.toggleSort === Q ? O : Q;
     return spec;
   };
 
@@ -370,7 +370,7 @@ module.exports = (function() {
   Encoding.toggleSort.direction = function(spec) {
     if (!Encoding.toggleSort.support(spec)) { return; }
     var enc = spec.enc;
-    return enc.x.type === 'O' ? 'x' :  'y';
+    return enc.x.type === O ? 'x' : 'y';
   };
 
   Encoding.toggleSort.mode = function(spec) {

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -50,7 +50,7 @@ module.exports = (function() {
   Encoding.shorthand = function (spec) {
     var c = consts.shorthand;
     return 'mark' + c.assign + spec.marktype +
-      c.delim + vlenc.shorthand(spec.enc);
+      c.delim + vlenc.shorthand(spec.encoding);
   };
 
   Encoding.specFromShorthand = function(shorthand, data, config, excludeConfig) {
@@ -307,18 +307,18 @@ module.exports = (function() {
   };
 
   Encoding.isAggregate = function(spec) {
-    return vlenc.isAggregate(spec.enc);
+    return vlenc.isAggregate(spec.encoding);
   };
 
   Encoding.alwaysNoOcclusion = function(spec) {
     // FIXME raw OxQ with # of rows = # of O
-    return vlenc.isAggregate(spec.enc);
+    return vlenc.isAggregate(spec.encoding);
   };
 
   Encoding.isStack = function(spec) {
     // FIXME update this once we have control for stack ...
     return (spec.marktype === 'bar' || spec.marktype === 'area') &&
-      spec.enc.color;
+      spec.encoding.color;
   };
 
   proto.isStack = function() {
@@ -349,13 +349,13 @@ module.exports = (function() {
   };
 
   Encoding.transpose = function(spec) {
-    var oldenc = spec.enc,
-      enc = util.duplicate(spec.enc);
+    var oldenc = spec.encoding,
+      enc = util.duplicate(spec.encoding);
     enc.x = oldenc.y;
     enc.y = oldenc.x;
     enc.row = oldenc.col;
     enc.col = oldenc.row;
-    spec.enc = enc;
+    spec.encoding = enc;
     return spec;
   };
 
@@ -368,8 +368,8 @@ module.exports = (function() {
 
   Encoding.toggleSort.direction = function(spec) {
     if (!Encoding.toggleSort.support(spec)) { return; }
-    var enc = spec.enc;
-    return enc.x.type === O ? 'x' : 'y';
+    var enc = spec.encoding;
+    return enc.x.type === N ? 'x' : 'y';
   };
 
   Encoding.toggleSort.mode = function(spec) {
@@ -377,8 +377,8 @@ module.exports = (function() {
   };
 
   Encoding.toggleSort.support = function(spec, stats) {
-    var enc = spec.enc,
-      isType = vlfield.isType;
+    var enc = spec.encoding,
+      isTypes = vlfield.isTypes;
 
     if (vlenc.has(enc, ROW) || vlenc.has(enc, COL) ||
       !vlenc.has(enc, X) || !vlenc.has(enc, Y) ||
@@ -386,8 +386,8 @@ module.exports = (function() {
       return false;
     }
 
-    return ( isType(enc.x, O) && vlfield.isMeasure(enc.y)) ? 'x' :
-      ( isType(enc.y, O) && vlfield.isMeasure(enc.x)) ? 'y' : false;
+    return ( isTypes(enc.x, [N, O]) && vlfield.isMeasure(enc.y)) ? 'x' :
+      ( isTypes(enc.y, [N, O]) && vlfield.isMeasure(enc.x)) ? 'y' : false;
   };
 
   Encoding.toggleFilterNullO = function(spec) {
@@ -401,7 +401,7 @@ module.exports = (function() {
   };
 
   Encoding.toggleFilterNullO.support = function(spec, stats) {
-    var fields = vlenc.fields(spec.enc);
+    var fields = vlenc.fields(spec.encoding);
     for (var fieldName in fields) {
       var fieldList = fields[fieldName];
       if (fieldList.containsType.O && fieldName in stats && stats[fieldName].nulls > 0) {

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -368,8 +368,8 @@ module.exports = (function() {
 
   Encoding.toggleSort.direction = function(spec) {
     if (!Encoding.toggleSort.support(spec)) { return; }
-    var enc = spec.encoding;
-    return enc.x.type === N ? 'x' : 'y';
+    var enc = spec.enc;
+    return enc.x.type === O ? 'x' : 'y';
   };
 
   Encoding.toggleSort.mode = function(spec) {
@@ -378,7 +378,7 @@ module.exports = (function() {
 
   Encoding.toggleSort.support = function(spec, stats) {
     var enc = spec.encoding,
-      isTypes = vlfield.isTypes;
+      isType = vlfield.isType;
 
     if (vlenc.has(enc, ROW) || vlenc.has(enc, COL) ||
       !vlenc.has(enc, X) || !vlenc.has(enc, Y) ||
@@ -386,8 +386,8 @@ module.exports = (function() {
       return false;
     }
 
-    return ( isTypes(enc.x, [N, O]) && vlfield.isMeasure(enc.y)) ? 'x' :
-      ( isTypes(enc.y, [N, O]) && vlfield.isMeasure(enc.x)) ? 'y' : false;
+    return ( isType(enc.x, O) && vlfield.isMeasure(enc.y)) ? 'x' :
+      ( isType(enc.y, O) && vlfield.isMeasure(enc.x)) ? 'y' : false;
   };
 
   Encoding.toggleFilterNullO = function(spec) {

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -129,8 +129,8 @@ module.exports = (function() {
       return f + 'count';
     } else if (!nofn && this._enc[et].bin) {
       return f + 'bin_' + this._enc[et].name;
-    } else if (!nofn && this._enc[et].aggr) {
-      return f + this._enc[et].aggr + '_' + this._enc[et].name;
+    } else if (!nofn && this._enc[et].aggregate) {
+      return f + this._enc[et].aggregate + '_' + this._enc[et].name;
     } else if (!nofn && this._enc[et].fn) {
       return f + this._enc[et].fn + '_' + this._enc[et].name;
     } else {
@@ -153,7 +153,7 @@ module.exports = (function() {
     if (vlfield.isCount(this._enc[et])) {
       return vlfield.count.displayName;
     }
-    var fn = this._enc[et].aggr || this._enc[et].fn || (this._enc[et].bin && "bin");
+    var fn = this._enc[et].aggregate || this._enc[et].fn || (this._enc[et].bin && "bin");
     if (fn) {
       return fn.toUpperCase() + '(' + this._enc[et].name + ')';
     } else {
@@ -184,8 +184,8 @@ module.exports = (function() {
       this.config(useSmallBand ? 'smallBandSize' : 'largeBandSize');
   };
 
-  proto.aggr = function(et) {
-    return this._enc[et].aggr;
+  proto.aggregate = function(et) {
+    return this._enc[et].aggregate;
   };
 
   // returns false if binning is disabled, otherwise an object with binning properties
@@ -227,7 +227,7 @@ module.exports = (function() {
       if (isType(enc[et], O)) {
         sort = [{
           name: qField.name,
-          aggr: qField.aggr,
+          aggregate: qField.aggregate,
           type: qField.type,
           reverse: true
         }];

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -31,6 +31,60 @@ module.exports = (function() {
 
   var proto = Encoding.prototype;
 
+  Encoding.fromShorthand = function(shorthand, data, config, theme) {
+    var c = consts.shorthand,
+        split = shorthand.split(c.delim),
+        marktype = split.shift().split(c.assign)[1].trim(),
+        enc = vlenc.fromShorthand(split);
+
+    return new Encoding(marktype, enc, data, config, null, theme);
+  };
+
+  Encoding.fromSpec = function(spec, theme) {
+    return new Encoding(spec.marktype, spec.enc, spec.data, spec.config, spec.filter, theme);
+  };
+
+  proto.toShorthand = function() {
+    var c = consts.shorthand;
+    return 'mark' + c.assign + this._marktype +
+      c.delim + vlenc.shorthand(this._enc);
+  };
+
+  Encoding.shorthand = function (spec) {
+    var c = consts.shorthand;
+    return 'mark' + c.assign + spec.marktype +
+      c.delim + vlenc.shorthand(spec.enc);
+  };
+
+  Encoding.specFromShorthand = function(shorthand, data, config, excludeConfig) {
+    return Encoding.fromShorthand(shorthand, data, config).toSpec(excludeConfig);
+  };
+
+  proto.toSpec = function(excludeConfig, excludeData) {
+    var enc = util.duplicate(this._enc),
+      spec;
+
+    spec = {
+      marktype: this._marktype,
+      enc: enc,
+      filter: this._filter
+    };
+
+    if (!excludeConfig) {
+      spec.config = util.duplicate(this._config);
+    }
+
+    if (!excludeData) {
+      spec.data = util.duplicate(this._data);
+    }
+
+    // remove defaults
+    var defaults = schema.instantiate();
+    return schema.util.subtract(spec, defaults);
+  };
+
+
+
   proto.marktype = function() {
     return this._marktype;
   };
@@ -295,58 +349,6 @@ module.exports = (function() {
 
   proto.config = function(name) {
     return this._config[name];
-  };
-
-  proto.toSpec = function(excludeConfig, excludeData) {
-    var enc = util.duplicate(this._enc),
-      spec;
-
-    spec = {
-      marktype: this._marktype,
-      enc: enc,
-      filter: this._filter
-    };
-
-    if (!excludeConfig) {
-      spec.config = util.duplicate(this._config);
-    }
-
-    if (!excludeData) {
-      spec.data = util.duplicate(this._data);
-    }
-
-    // remove defaults
-    var defaults = schema.instantiate();
-    return schema.util.subtract(spec, defaults);
-  };
-
-  proto.toShorthand = function() {
-    var c = consts.shorthand;
-    return 'mark' + c.assign + this._marktype +
-      c.delim + vlenc.shorthand(this._enc);
-  };
-
-  Encoding.shorthand = function (spec) {
-    var c = consts.shorthand;
-    return 'mark' + c.assign + spec.marktype +
-      c.delim + vlenc.shorthand(spec.enc);
-  };
-
-  Encoding.fromShorthand = function(shorthand, data, config, theme) {
-    var c = consts.shorthand,
-        split = shorthand.split(c.delim),
-        marktype = split.shift().split(c.assign)[1].trim(),
-        enc = vlenc.fromShorthand(split);
-
-    return new Encoding(marktype, enc, data, config, null, theme);
-  };
-
-  Encoding.specFromShorthand = function(shorthand, data, config, excludeConfig) {
-    return Encoding.fromShorthand(shorthand, data, config).toSpec(excludeConfig);
-  };
-
-  Encoding.fromSpec = function(spec, theme) {
-    return new Encoding(spec.marktype, spec.enc, spec.data, spec.config, spec.filter, theme);
   };
 
   Encoding.transpose = function(spec) {

--- a/src/compile/aggregate.js
+++ b/src/compile/aggregate.js
@@ -13,12 +13,12 @@ function aggregates(spec, encoding, opt) {
     data = spec.data[1]; // currently data[0] is raw and data[1] is table
 
   encoding.forEach(function(field, encType) {
-    if (field.aggr) {
-      if (field.aggr === 'count') {
+    if (field.aggregate) {
+      if (field.aggregate === 'count') {
         meas.count = {op: 'count', field: '*'};
       }else {
-        meas[field.aggr + '|'+ field.name] = {
-          op: field.aggr,
+        meas[field.aggregate + '|'+ field.name] = {
+          op: field.aggregate,
           field: 'data.'+ field.name
         };
       }

--- a/src/compile/layout.js
+++ b/src/compile/layout.js
@@ -101,7 +101,7 @@ function offset(encoding, stats, layout) {
     var maxLength;
     if (encoding.isDimension(x) || encoding.isType(x, T)) {
       maxLength =  getMaxLength(encoding, stats, x);
-    } else if (encoding.aggr(x) === 'count') {
+    } else if (encoding.aggregate(x) === 'count') {
       //assign default value for count as it won't have stats
       maxLength =  3;
     } else if (encoding.isType(x, Q)) {

--- a/src/compile/sort.js
+++ b/src/compile/sort.js
@@ -16,14 +16,14 @@ function addSortTransforms(spec, encoding, stats, opt) {
     if (sortBy.length > 0) {
       var fields = sortBy.map(function(d) {
         return {
-          op: d.aggr,
+          op: d.aggregate,
           field: 'data.' + d.name
         };
       });
 
       var byClause = sortBy.map(function(d) {
         var reverse = (d.reverse ? '-' : '');
-        return reverse + 'data.' + (d.aggr==='count' ? 'count' : (d.aggr + '_' + d.name));
+        return reverse + 'data.' + (d.aggregate==='count' ? 'count' : (d.aggregate + '_' + d.name));
       });
 
       var dataName = 'sorted' + counter++;

--- a/src/compile/stack.js
+++ b/src/compile/stack.js
@@ -35,7 +35,7 @@ function stacking(spec, encoding, mdef, facets) {
     transform: [{
       type: 'aggregate',
       groupby: [encoding.field(dim)].concat(facets), // dim and other facets
-      fields: [{op: 'sum', field: encoding.field(val)}] // TODO check if field with aggr is correct?
+      fields: [{op: 'sum', field: encoding.field(val)}] // TODO check if field with aggregate is correct?
     }]
   };
 

--- a/src/data.js
+++ b/src/data.js
@@ -1,13 +1,15 @@
 'use strict';
 
+require('./globals');
+
 var vldata = module.exports = {};
 
 /** Mapping from datalib's inferred type to Vega-lite's type */
 vldata.types = {
-  'boolean': 'O',
-  'number': 'Q',
-  'integer': 'Q',
-  'date': 'T',
-  'string': 'O'
+  'boolean': O,
+  'number': Q,
+  'integer': Q,
+  'date': T,
+  'string': O
 };
 

--- a/src/enc.js
+++ b/src/enc.js
@@ -27,7 +27,7 @@ vlenc.has = function(enc, encType) {
 
 vlenc.isAggregate = function(enc) {
   for (var k in enc) {
-    if (vlenc.has(enc, k) && enc[k].aggr) {
+    if (vlenc.has(enc, k) && enc[k].aggregate) {
       return true;
     }
   }

--- a/src/field.js
+++ b/src/field.js
@@ -14,7 +14,7 @@ var vlfield = module.exports = {};
 
 vlfield.shorthand = function(f) {
   var c = consts.shorthand;
-  return (f.aggr ? f.aggr + c.func : '') +
+  return (f.aggregate ? f.aggregate + c.func : '') +
     (f.fn ? f.fn + c.func : '') +
     (f.bin ? 'bin' + c.func : '') +
     (f.name || '') + c.type + f.type;
@@ -33,12 +33,12 @@ vlfield.fromShorthand = function(shorthand) {
   };
 
   // check aggregate type
-  for (i in schema.aggr.enum) {
-    var a = schema.aggr.enum[i];
+  for (i in schema.aggregate.enum) {
+    var a = schema.aggregate.enum[i];
     if (o.name.indexOf(a + '_') === 0) {
       o.name = o.name.substr(a.length + 1);
       if (a == 'count' && o.name.length === 0) o.name = '*';
-      o.aggr = a;
+      o.aggregate = a;
       break;
     }
   }
@@ -72,7 +72,7 @@ var typeOrder = {
 vlfield.order = {};
 
 vlfield.order.type = function(field) {
-  if (field.aggr==='count') return 4;
+  if (field.aggregate==='count') return 4;
   return typeOrder[field.type];
 };
 
@@ -128,13 +128,13 @@ vlfield.role = function(field) {
 };
 
 vlfield.count = function() {
-  return {name:'*', aggr: 'count', type: Q, displayName: vlfield.count.displayName};
+  return {name:'*', aggregate: 'count', type: Q, displayName: vlfield.count.displayName};
 };
 
 vlfield.count.displayName = 'Number of Records';
 
 vlfield.isCount = function(field) {
-  return field.aggr === 'count';
+  return field.aggregate === 'count';
 };
 
 /**
@@ -158,7 +158,7 @@ vlfield.cardinality = function(field, stats, filterNull) {
     if(cardinality !== null) return cardinality;
     //otherwise use calculation below
   }
-  if (field.aggr) {
+  if (field.aggregate) {
     return 1;
   }
 

--- a/src/field.js
+++ b/src/field.js
@@ -2,6 +2,8 @@
 
 // utility for field
 
+require('./globals');
+
 var consts = require('./consts'),
   c = consts.shorthand,
   time = require('./compile/time'),
@@ -126,7 +128,7 @@ vlfield.role = function(field) {
 };
 
 vlfield.count = function() {
-  return {name:'*', aggr: 'count', type:'Q', displayName: vlfield.count.displayName};
+  return {name:'*', aggr: 'count', type: Q, displayName: vlfield.count.displayName};
 };
 
 vlfield.count.displayName = 'Number of Records';

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -14,7 +14,7 @@ schema.marktype = {
   enum: ['point', 'tick', 'bar', 'line', 'area', 'circle', 'square', 'text']
 };
 
-schema.aggr = {
+schema.aggregate = {
   type: 'string',
   enum: ['avg', 'sum', 'median', 'min', 'max', 'count'],
   supportedEnums: {
@@ -97,7 +97,7 @@ var typicalField = merge(clone(schema.field), {
       type: 'string',
       enum: [O, Q, T]
     },
-    aggr: schema.aggr,
+    aggregate: schema.aggregate,
     fn: schema.fn,
     bin: bin,
     scale: {
@@ -137,7 +137,7 @@ var onlyOrdinalField = merge(clone(schema.field), {
     },
     fn: schema.fn,
     bin: bin,
-    aggr: {
+    aggregate: {
       type: 'string',
       enum: ['count'],
       supportedTypes: toMap([O])
@@ -192,11 +192,11 @@ var sortMixin = {
       items: {
         type: 'object',
         supportedTypes: toMap([O]),
-        required: ['name', 'aggr'],
+        required: ['name', 'aggregate'],
         name: {
           type: 'string'
         },
-        aggr: {
+        aggregate: {
           type: 'string',
           enum: ['avg', 'sum', 'min', 'max', 'count']
         },

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -41,7 +41,7 @@ schema.band = {
 };
 
 schema.getSupportedRole = function(encType) {
-  return schema.schema.properties.enc.properties[encType].supportedRole;
+  return schema.schema.properties.encoding.properties[encType].supportedRole;
 };
 
 schema.timefns = ['year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds'];
@@ -606,7 +606,7 @@ schema.schema = {
   properties: {
     data: data,
     marktype: schema.marktype,
-    enc: {
+    encoding: {
       type: 'object',
       properties: {
         x: x,
@@ -626,7 +626,7 @@ schema.schema = {
   }
 };
 
-schema.encTypes = util.keys(schema.schema.properties.enc.properties);
+schema.encTypes = util.keys(schema.schema.properties.encoding.properties);
 
 /** Instantiate a verbose vl spec from the schema */
 schema.instantiate = function() {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -1,8 +1,11 @@
 // Package of defining Vega-lite Specification's json schema
 "use strict";
 
+require('../globals');
+
 var schema = module.exports = {},
-  util = require('../util');
+  util = require('../util'),
+  toMap = util.toMap;
 
 schema.util = require('./schemautil');
 
@@ -20,7 +23,7 @@ schema.aggr = {
     T: ['avg', 'median', 'min', 'max'],
     '': ['count']
   },
-  supportedTypes: {'Q': true, 'O': true, 'T': true, '': true}
+  supportedTypes: toMap([Q, O, T, ''])
 };
 schema.band = {
   type: 'object',
@@ -48,7 +51,7 @@ schema.defaultTimeFn = 'month';
 schema.fn = {
   type: 'string',
   enum: schema.timefns,
-  supportedTypes: {'T': true}
+  supportedTypes: toMap([T])
 };
 
 //TODO(kanitw): add other type of function here
@@ -57,7 +60,7 @@ schema.scale_type = {
   type: 'string',
   enum: ['linear', 'log', 'pow', 'sqrt', 'quantile'],
   default: 'linear',
-  supportedTypes: {'Q': true}
+  supportedTypes: toMap([Q])
 };
 
 schema.field = {
@@ -84,7 +87,7 @@ var bin = {
       minimum: 2
     }
   },
-  supportedTypes: {'Q': true} // TODO: add 'O' after finishing #81
+  supportedTypes: toMap([Q]) // TODO: add O after finishing #81
 };
 
 var typicalField = merge(clone(schema.field), {
@@ -92,7 +95,7 @@ var typicalField = merge(clone(schema.field), {
   properties: {
     type: {
       type: 'string',
-      enum: ['O', 'Q', 'T']
+      enum: [O, Q, T]
     },
     aggr: schema.aggr,
     fn: schema.fn,
@@ -104,18 +107,18 @@ var typicalField = merge(clone(schema.field), {
         reverse: {
           type: 'boolean',
           default: false,
-          supportedTypes: {'Q': true, 'T': true}
+          supportedTypes: toMap([Q, T])
         },
         zero: {
           type: 'boolean',
           description: 'Include zero',
           default: true,
-          supportedTypes: {'Q': true, 'T': true}
+          supportedTypes: toMap([Q, T])
         },
         nice: {
           type: 'string',
           enum: ['second', 'minute', 'hour', 'day', 'week', 'month', 'year'],
-          supportedTypes: {'T': true}
+          supportedTypes: toMap([T])
         }
       }
     }
@@ -130,14 +133,14 @@ var onlyOrdinalField = merge(clone(schema.field), {
   properties: {
     type: {
       type: 'string',
-      enum: ['O','Q', 'T'] // ordinal-only field supports Q when bin is applied and T when fn is applied.
+      enum: [O, Q, T] // ordinal-only field supports Q when bin is applied and T when fn is applied.
     },
     fn: schema.fn,
     bin: bin,
     aggr: {
       type: 'string',
       enum: ['count'],
-      supportedTypes: {'O': true}
+      supportedTypes: toMap([O])
     }
   }
 });
@@ -188,7 +191,7 @@ var sortMixin = {
       default: [],
       items: {
         type: 'object',
-        supportedTypes: {'O': true},
+        supportedTypes: toMap([O]),
         required: ['name', 'aggr'],
         name: {
           type: 'string'
@@ -509,7 +512,7 @@ var config = {
     },
     toggleSort: {
       type: 'string',
-      default: 'O'
+      default: O
     },
 
     // single plot

--- a/test/Encoding.spec.js
+++ b/test/Encoding.spec.js
@@ -17,7 +17,7 @@ describe('Encoding.fromShorthand()', function () {
 describe('encoding.filter()', function () {
   var spec = {
       marktype: 'point',
-      enc: {
+      encoding: {
         y: {name: 'Q', type:'Q'},
         x: {name: 'T', type:'T'},
         color: {name: 'O', type:'O'}

--- a/test/compile/axis.spec.js
+++ b/test/compile/axis.spec.js
@@ -10,7 +10,7 @@ describe('Axis', function() {
     var fieldName = 'a',
       fn = 'month',
       encoding = Encoding.fromSpec({
-        enc: {
+        encoding: {
           x: {name: fieldName, type: 'T', fn: fn}
         }
       });

--- a/test/compile/sort.spec.js
+++ b/test/compile/sort.spec.js
@@ -9,13 +9,13 @@ describe('Sort', function() {
   var encoding = Encoding.fromSpec({
         encoding: {
           x: {name: 'foo', type: 'O', sort: [{
-            name: 'bar', aggr: 'avg'
+            name: 'bar', aggregate: 'avg'
           }]},
           y: {name: 'bar', type: 'Q'},
           color: {name: 'baz', type: 'O', sort: [{
-            name: 'bar', aggr: 'sum'
+            name: 'bar', aggregate: 'sum'
           }, {
-            name: 'foo', aggr: 'max', reverse: true
+            name: 'foo', aggregate: 'max', reverse: true
           }]}
         }
       }),

--- a/test/compile/sort.spec.js
+++ b/test/compile/sort.spec.js
@@ -7,7 +7,7 @@ var vlsort = require('../../src/compile/sort'),
 
 describe('Sort', function() {
   var encoding = Encoding.fromSpec({
-        enc: {
+        encoding: {
           x: {name: 'foo', type: 'O', sort: [{
             name: 'bar', aggr: 'avg'
           }]},

--- a/test/compile/stack.spec.js
+++ b/test/compile/stack.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var expect = require('chai').expect;
+var fixtures = require('../fixtures').stack;
 
 var compile = require('../../src/compile/compile'),
   util = require('../../src/util');
@@ -14,23 +15,6 @@ util.getbins = function() {
   };
 };
 
-var spec_stackBinY = {
-  "marktype": "bar",
-  "enc": {
-    "x": {"type": "Q","name": "Cost__Other","aggr": "avg"},
-    "y": {"bin": true,"type": "Q","name": "Cost__Total_$"},
-    "color": {"type": "O","name": "Effect__Amount_of_damage"}
-  }
-};
-
-var spec_stackBinX = {
-  "marktype": "bar",
-  "enc": {
-    "y": {"type": "Q","name": "Cost__Other","aggr": "avg"},
-    "x": {"bin": true,"type": "Q","name": "Cost__Total_$"},
-    "color": {"type": "O","name": "Effect__Amount_of_damage"}
-  }
-};
 
 var stats = {
   'Cost__Total_$': {
@@ -54,7 +38,7 @@ describe('vl.compile.stack()', function () {
 
   describe('bin-x', function () {
     it('should put stack on y', function () {
-      var vgSpec = compile(spec_stackBinX, stats);
+      var vgSpec = compile(fixtures.binX, stats);
 
       var tableData = vgSpec.data.filter(function(data) {
         return data.name === 'table';
@@ -78,7 +62,7 @@ describe('vl.compile.stack()', function () {
 
   describe('bin-y', function () {
     it('should put stack on x', function () {
-      var vgSpec = compile(spec_stackBinY, stats);
+      var vgSpec = compile(fixtures.binY, stats);
 
       var tableData = vgSpec.data.filter(function(data) {
         return data.name === 'table';

--- a/test/compile/time.spec.js
+++ b/test/compile/time.spec.js
@@ -9,7 +9,7 @@ describe('Time', function() {
   var fieldName = 'a',
     fn = 'month',
     encoding = Encoding.fromSpec({
-      enc: {
+      encoding: {
         x: {name: fieldName, type: 'T', fn: fn}
       }
     }),

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -8,7 +8,7 @@ f.bars.log_ver = {
   "marktype": "bar",
   encoding: {
     "x": {"bin": {"maxbins": 15},"type": "Q","name": "IMDB_Rating"},
-    "y": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggr": "avg"}
+    "y": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggregate": "avg"}
   },
   "config": {"singleHeight": 400,"singleWidth": 400,"largeBandMaxCardinality": 20},
   "data": {"url": "data/movies.json"}
@@ -18,7 +18,7 @@ f.bars.log_hor = {
   "marktype": "bar",
   encoding: {
     "y": {"bin": {"maxbins": 15},"type": "Q","name": "IMDB_Rating"},
-    "x": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggr": "avg"}
+    "x": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggregate": "avg"}
   },
   "config": {"singleHeight": 400,"singleWidth": 400,"largeBandMaxCardinality": 20},
   "data": {"url": "data/movies.json"}
@@ -26,7 +26,7 @@ f.bars.log_hor = {
 
 f.bars['1d_hor'] = {
   "marktype": "bar",
-  encoding: {"x": {"type": "Q","name": "US_Gross","aggr": "sum"}},
+  encoding: {"x": {"type": "Q","name": "US_Gross","aggregate": "sum"}},
   "config": {"singleHeight": 400,"singleWidth": 400,"largeBandMaxCardinality": 20},
   "data": {"url": "data/movies.json"}
 };
@@ -34,7 +34,7 @@ f.bars['1d_hor'] = {
 
 f.bars['1d_ver'] = {
   "marktype": "bar",
-  encoding: {"y": {"type": "Q","name": "US_Gross","aggr": "sum"}},
+  encoding: {"y": {"type": "Q","name": "US_Gross","aggregate": "sum"}},
   "config": {"singleHeight": 400,"singleWidth": 400,"largeBandMaxCardinality": 20},
   "data": {"url": "data/movies.json"}
 };
@@ -46,7 +46,7 @@ f.stack = {};
 f.stack.binY = {
   "marktype": "bar",
   "encoding": {
-    "x": {"type": "Q","name": "Cost__Other","aggr": "avg"},
+    "x": {"type": "Q","name": "Cost__Other","aggregate": "avg"},
     "y": {"bin": true,"type": "Q","name": "Cost__Total_$"},
     "color": {"type": "O","name": "Effect__Amount_of_damage"}
   }
@@ -54,7 +54,7 @@ f.stack.binY = {
 f.stack.binX = {
   "marktype": "bar",
   "encoding": {
-    "y": {"type": "Q","name": "Cost__Other","aggr": "avg"},
+    "y": {"type": "Q","name": "Cost__Other","aggregate": "avg"},
     "x": {"bin": true,"type": "Q","name": "Cost__Total_$"},
     "color": {"type": "O","name": "Effect__Amount_of_damage"}
   }

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,10 +1,12 @@
 var f = {};
 
+// BARS
+
 f.bars = {};
 
 f.bars.log_ver = {
   "marktype": "bar",
-  "enc": {
+  encoding: {
     "x": {"bin": {"maxbins": 15},"type": "Q","name": "IMDB_Rating"},
     "y": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggr": "avg"}
   },
@@ -14,7 +16,7 @@ f.bars.log_ver = {
 
 f.bars.log_hor = {
   "marktype": "bar",
-  "enc": {
+  encoding: {
     "y": {"bin": {"maxbins": 15},"type": "Q","name": "IMDB_Rating"},
     "x": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggr": "avg"}
   },
@@ -24,7 +26,7 @@ f.bars.log_hor = {
 
 f.bars['1d_hor'] = {
   "marktype": "bar",
-  "enc": {"x": {"type": "Q","name": "US_Gross","aggr": "sum"}},
+  encoding: {"x": {"type": "Q","name": "US_Gross","aggr": "sum"}},
   "config": {"singleHeight": 400,"singleWidth": 400,"largeBandMaxCardinality": 20},
   "data": {"url": "data/movies.json"}
 };
@@ -32,9 +34,30 @@ f.bars['1d_hor'] = {
 
 f.bars['1d_ver'] = {
   "marktype": "bar",
-  "enc": {"y": {"type": "Q","name": "US_Gross","aggr": "sum"}},
+  encoding: {"y": {"type": "Q","name": "US_Gross","aggr": "sum"}},
   "config": {"singleHeight": 400,"singleWidth": 400,"largeBandMaxCardinality": 20},
   "data": {"url": "data/movies.json"}
 };
 
-module.exports = f; 
+// STACK
+
+f.stack = {};
+
+f.stack.binY = {
+  "marktype": "bar",
+  "encoding": {
+    "x": {"type": "Q","name": "Cost__Other","aggr": "avg"},
+    "y": {"bin": true,"type": "Q","name": "Cost__Total_$"},
+    "color": {"type": "O","name": "Effect__Amount_of_damage"}
+  }
+};
+f.stack.binX = {
+  "marktype": "bar",
+  "encoding": {
+    "y": {"type": "Q","name": "Cost__Other","aggr": "avg"},
+    "x": {"bin": true,"type": "Q","name": "Cost__Total_$"},
+    "color": {"type": "O","name": "Effect__Amount_of_damage"}
+  }
+};
+
+module.exports = f;

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -28,7 +28,7 @@ describe('Schema', function() {
   });
 
   it('field def should have supportedMarktypes', function() {
-    var encProps = specSchema.properties.enc.properties;
+    var encProps = specSchema.properties.encoding.properties;
     for (var k in encProps) {
       assert.notEqual(encProps[k].supportedMarktypes, undefined);
     }
@@ -51,7 +51,7 @@ describe('Util', function() {
   it('remove defaults', function() {
     var spec = {
       marktype: 'point',
-      enc: {
+      encoding: {
         x: { name: 'dsp', type: 'Q', scale: {type: 'linear'}
       },
         color: { name: 'cyl', type: 'O' }
@@ -64,7 +64,7 @@ describe('Util', function() {
 
     var expected = {
       marktype: 'point',
-      enc: {
+      encoding: {
         x: { name: 'dsp', type: 'Q' },
         color: { name: 'cyl', type: 'O' }
       },


### PR DESCRIPTION
fixing #436 

- [x] `.enc` => `.encoding`
- [x] `.aggr` => `.aggregate`
- [ ] `.fn` => ???

~~`aggregate: 'avg'` => `aggregate: ‘average’`~~ — We will change this once we migrate to Vega2. 