### PR TITLE
Test coverage using istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vega-lite*.map
 spec.json
 npm-debug.log
 instance.json
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 before_install:
   - npm install -g gulp
 install: npm install
-
+after_success: ./node_modules/.bin/coveralls --verbose < coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Vega-lite [![Build Status](https://travis-ci.org/uwdata/vega-lite.svg)](https://travis-ci.org/uwdata/vega-lite)  [![npm dependencies](https://david-dm.org/uwdata/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) [![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite)
+# Vega-lite 
+
+[![Build Status](https://travis-ci.org/uwdata/vega-lite.svg)](https://travis-ci.org/uwdata/vega-lite) 
+[![npm dependencies](https://david-dm.org/uwdata/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) 
+[![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) 
+[![Coverage Status](https://coveralls.io/repos/uwdata/vega-lite/badge.svg?branch=kw%2Fistanbul)](https://coveralls.io/r/uwdata/vega-lite?branch=kw%2Fistanbul)
 
 **Vega-lite is work in progress and we are working on improving the code and documentation.**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/uwdata/vega-lite.svg)](https://travis-ci.org/uwdata/vega-lite) 
 [![npm dependencies](https://david-dm.org/uwdata/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) 
 [![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) 
-[![Coverage Status](https://coveralls.io/repos/uwdata/vega-lite/badge.svg?branch=kw%2Fistanbul)](https://coveralls.io/r/uwdata/vega-lite?branch=kw%2Fistanbul)
+[![Coverage Status](https://coveralls.io/repos/uwdata/vega-lite/badge.svg)](https://coveralls.io/r/uwdata/vega-lite)
 
 **Vega-lite is work in progress and we are working on improving the code and documentation.**
 

--- a/gulp/tests.js
+++ b/gulp/tests.js
@@ -7,6 +7,8 @@ var mocha = require('gulp-spawn-mocha');
 // runs the tests
 gulp.task('test', ['jshint'], function() {
   return gulp.src(['test/**/*.spec.js'], { read: false })
-    .pipe(mocha())
+    .pipe(mocha({
+      istanbul: true
+    }))
     .on('error', gutil.log);
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "browserify-shim": "^3.8.5",
     "chai": "^1.10.0",
     "commander": "^2.6.0",
+    "coveralls": "^2.11.2",
     "d3": "^3.5.5",
     "deep-diff": "^0.3.0",
     "gulp": "^3.8.10",


### PR DESCRIPTION
Now we can look at test coverage online at https://coveralls.io/r/uwdata/vega-lite.  

Right now, we’re at 63% — quite low, but honestly surprisingly high given how much test we wrote. 

I am figuring out about local/offline line coverage reporter.  