### PR TITLE
Refactor compile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "main": "vega-lite.js",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "homepage": "https://github.com/uwdata/vega-lite",
   "authors": [
     "Kanit Wongsuphasawat <kanitw@gmail.com> (http://kanitw.yellowpigz.com)",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "main": "vega-lite.js",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "homepage": "https://github.com/uwdata/vega-lite",
   "authors": [
     "Kanit Wongsuphasawat <kanitw@gmail.com> (http://kanitw.yellowpigz.com)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "author": "Jeffrey Heer, Dominik Moritz, Kanit \"Ham\" Wongsuphasawat",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "collaborators": [
     "Kanit Wongsuphasawat <kanitw@gmail.com> (http://kanitw.yellowpigz.com)",
     "Dominik Moritz <domoritz@cs.washington.edu> (http://domoritz.de)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "author": "Jeffrey Heer, Dominik Moritz, Kanit \"Ham\" Wongsuphasawat",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "collaborators": [
     "Kanit Wongsuphasawat <kanitw@gmail.com> (http://kanitw.yellowpigz.com)",
     "Dominik Moritz <domoritz@cs.washington.edu> (http://domoritz.de)",

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -124,14 +124,20 @@ module.exports = (function() {
   // get "field" property for vega
   proto.field = function(et, nodata, nofn) {
     if (!this.has(et)) return null;
-    return vlfield.fieldName(this._enc[et], {
+    return vlfield.fieldRef(this._enc[et], {
       nofn: nofn,
       data: !this._vega2 && !nodata
     });
   };
 
-  proto.fieldName = function(et, opt) {
-    return vlfield.fieldName(this._enc[et], opt);
+  proto.fieldRef = function(et, opt) {
+    opt = opt || {};
+    opt.data = !this._vega2 && (opt.data !== false);
+    return vlfield.fieldRef(this._enc[et], opt);
+  };
+
+  proto.fieldName = function(et) {
+    return this._enc[et].name;
   };
 
   /*

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -124,11 +124,14 @@ module.exports = (function() {
   // get "field" property for vega
   proto.field = function(et, nodata, nofn) {
     if (!this.has(et)) return null;
-    return vlfield.field(this._enc[et], nofn, nodata || this._vega2);
+    return vlfield.fieldName(this._enc[et], {
+      nofn: nofn,
+      data: !this._vega2 && !nodata
+    });
   };
 
-  proto.fieldName = function(et) {
-    return this._enc[et].name;
+  proto.fieldName = function(et, opt) {
+    return vlfield.fieldName(this._enc[et], opt);
   };
 
   /*

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -18,6 +18,7 @@ module.exports = (function() {
     this._enc = specExtended.encoding;
     this._config = specExtended.config;
     this._filter = specExtended.filter;
+    // this._vega2 = true;
   }
 
   var proto = Encoding.prototype;
@@ -123,20 +124,7 @@ module.exports = (function() {
   // get "field" property for vega
   proto.field = function(et, nodata, nofn) {
     if (!this.has(et)) return null;
-
-    var f = (nodata ? '' : 'data.');
-
-    if (vlfield.isCount(this._enc[et])) {
-      return f + 'count';
-    } else if (!nofn && this._enc[et].bin) {
-      return f + 'bin_' + this._enc[et].name;
-    } else if (!nofn && this._enc[et].aggregate) {
-      return f + this._enc[et].aggregate + '_' + this._enc[et].name;
-    } else if (!nofn && this._enc[et].timeUnit) {
-      return f + this._enc[et].timeUnit + '_' + this._enc[et].name;
-    } else {
-      return f + this._enc[et].name;
-    }
+    return vlfield.field(this._enc[et], nofn, nodata || this._vega2);
   };
 
   proto.fieldName = function(et) {

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -132,8 +132,8 @@ module.exports = (function() {
       return f + 'bin_' + this._enc[et].name;
     } else if (!nofn && this._enc[et].aggregate) {
       return f + this._enc[et].aggregate + '_' + this._enc[et].name;
-    } else if (!nofn && this._enc[et].fn) {
-      return f + this._enc[et].fn + '_' + this._enc[et].name;
+    } else if (!nofn && this._enc[et].timeUnit) {
+      return f + this._enc[et].timeUnit + '_' + this._enc[et].name;
     } else {
       return f + this._enc[et].name;
     }
@@ -154,9 +154,9 @@ module.exports = (function() {
     if (vlfield.isCount(this._enc[et])) {
       return vlfield.count.displayName;
     }
-    var fn = this._enc[et].aggregate || this._enc[et].fn || (this._enc[et].bin && 'bin');
-    if (fn) {
-      return fn.toUpperCase() + '(' + this._enc[et].name + ')';
+    var timeUnit = this._enc[et].aggregate || this._enc[et].timeUnit || (this._enc[et].bin && 'bin');
+    if (timeUnit) {
+      return timeUnit.toUpperCase() + '(' + this._enc[et].name + ')';
     } else {
       return this._enc[et].name;
     }
@@ -209,8 +209,8 @@ module.exports = (function() {
     return this._enc[et].value;
   };
 
-  proto.fn = function(et) {
-    return this._enc[et].fn;
+  proto.timeUnit = function(et) {
+    return this._enc[et].timeUnit;
   };
 
   proto.sort = function(et, stats) {

--- a/src/compile/aggregate.js
+++ b/src/compile/aggregate.js
@@ -6,11 +6,10 @@ var util = require('../util');
 
 module.exports = aggregates;
 
-function aggregates(spec, encoding, opt) {
+function aggregates(dataTable, encoding, opt) {
   opt = opt || {};
 
-  var dims = {}, meas = {}, detail = {}, facets = {},
-    data = spec.data[1]; // currently data[0] is raw and data[1] is table
+  var dims = {}, meas = {}, detail = {}, facets = {};
 
   encoding.forEach(function(field, encType) {
     if (field.aggregate) {
@@ -19,7 +18,7 @@ function aggregates(spec, encoding, opt) {
       }else {
         meas[field.aggregate + '|'+ field.name] = {
           op: field.aggregate,
-          field: 'data.'+ field.name
+          field: encoding.field(encType, false, true)
         };
       }
     } else {
@@ -35,8 +34,8 @@ function aggregates(spec, encoding, opt) {
   meas = util.vals(meas);
 
   if (meas.length > 0) {
-    if (!data.transform) data.transform = [];
-    data.transform.push({
+    if (!dataTable.transform) dataTable.transform = [];
+    dataTable.transform.push({
       type: 'aggregate',
       groupby: dims,
       fields: meas

--- a/src/compile/aggregate.js
+++ b/src/compile/aggregate.js
@@ -18,7 +18,7 @@ function aggregates(dataTable, encoding, opt) {
       }else {
         meas[field.aggregate + '|'+ field.name] = {
           op: field.aggregate,
-          field: encoding.field(encType, false, true)
+          field: encoding.fieldRef(encType, {nofn: true})
         };
       }
     } else {

--- a/src/compile/axis.js
+++ b/src/compile/axis.js
@@ -159,10 +159,10 @@ function axis_title(def, name, encoding, layout, opt) {
 function axis_labels(def, name, encoding, layout, opt) {
   // jshint unused:false
 
-  var fn;
+  var timeUnit;
   // add custom label for time type
-  if (encoding.isType(name, T) && (fn = encoding.fn(name)) && (time.hasScale(fn))) {
-    setter(def, ['properties','labels','text','scale'], 'time-'+ fn);
+  if (encoding.isType(name, T) && (timeUnit = encoding.timeUnit(name)) && (time.hasScale(timeUnit))) {
+    setter(def, ['properties','labels','text','scale'], 'time-'+ timeUnit);
   }
 
   var textTemplatePath = ['properties','labels','text','template'];
@@ -171,9 +171,9 @@ function axis_labels(def, name, encoding, layout, opt) {
   } else if (encoding.isType(name, Q)) {
     setter(def, textTemplatePath, '{{data | number:\'.3s\'}}');
   } else if (encoding.isType(name, T)) {
-    if (!encoding.fn(name)) {
+    if (!encoding.timeUnit(name)) {
       setter(def, textTemplatePath, '{{data | time:\'%Y-%m-%d\'}}');
-    } else if (encoding.fn(name) === 'year') {
+    } else if (encoding.timeUnit(name) === 'year') {
       setter(def, textTemplatePath, '{{data | number:\'d\'}}');
     }
   } else if (encoding.isType(name, [N, O]) && encoding.axis(name).maxLabelLength) {

--- a/src/compile/bin.js
+++ b/src/compile/bin.js
@@ -13,8 +13,8 @@ function binning(dataTable, encoding, opt) {
     if (encoding.bin(encType)) {
       dataTable.transform.push({
         type: 'bin',
-        field: 'data.' + field.name,
-        output: 'data.bin_' + field.name,
+        field: encoding.field(encType, false, /*nofn*/ true),
+        output: encoding.field(encType),
         maxbins: encoding.bin(encType).maxbins
       });
     }

--- a/src/compile/bin.js
+++ b/src/compile/bin.js
@@ -4,14 +4,14 @@ require('../globals');
 
 module.exports = binning;
 
-function binning(spec, encoding, opt) {
+function binning(dataTable, encoding, opt) {
   opt = opt || {};
 
-  if (!spec.transform) spec.transform = [];
+  if (!dataTable.transform) dataTable.transform = [];
 
   encoding.forEach(function(field, encType) {
     if (encoding.bin(encType)) {
-      spec.transform.push({
+      dataTable.transform.push({
         type: 'bin',
         field: 'data.' + field.name,
         output: 'data.bin_' + field.name,

--- a/src/compile/bin.js
+++ b/src/compile/bin.js
@@ -19,4 +19,6 @@ function binning(dataTable, encoding, opt) {
       });
     }
   });
+
+  return dataTable;
 }

--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -52,7 +52,7 @@ compile.encoding = function (encoding, stats) {
     dataTable = spec.data[1];
 
   filter.addFilters(spec, encoding);
-  var sorting = compile.sort(spec, encoding, stats);
+  var sorting = compile.sort(spec.data, encoding, stats);
 
   var hasRow = encoding.has(ROW), hasCol = encoding.has(COL);
 

--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -55,7 +55,6 @@ compile.encoding = function (encoding, stats) {
   filter.addFilters(rawTable, encoding);
   var sorting = compile.sort(spec.data, encoding, stats);
 
-  var hasRow = encoding.has(ROW), hasCol = encoding.has(COL);
 
   for (var i = 0; i < mdefs.length; i++) {
     group.marks.push(mdefs[i]);
@@ -88,7 +87,7 @@ compile.encoding = function (encoding, stats) {
   }
 
   // Small Multiples
-  if (hasRow || hasCol) {
+  if (encoding.has(ROW) || encoding.has(COL)) {
     spec = compile.facet(group, encoding, layout, style, sorting, spec, mdef, stack, stats);
     spec.legends = legend.defs(encoding);
   } else {

--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -48,7 +48,8 @@ compile.encoding = function (encoding, stats) {
     group = spec.marks[0],
     mark = marks[encoding.marktype()],
     mdefs = marks.def(mark, encoding, layout, style),
-    mdef = mdefs[0];  // TODO: remove this dirty hack by refactoring the whole flow
+    mdef = mdefs[0],  // TODO: remove this dirty hack by refactoring the whole flow
+    dataTable = spec.data[1];
 
   filter.addFilters(spec, encoding);
   var sorting = compile.sort(spec, encoding, stats);
@@ -59,7 +60,7 @@ compile.encoding = function (encoding, stats) {
     group.marks.push(mdefs[i]);
   }
 
-  compile.bin(spec.data[1], encoding);
+  compile.bin(dataTable, encoding);
 
   var lineType = marks[encoding.marktype()].line;
 

--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -67,7 +67,7 @@ compile.encoding = function (encoding, stats) {
   spec = compile.time(spec, encoding);
 
   // handle subfacets
-  var aggResult = compile.aggregate(spec, encoding),
+  var aggResult = compile.aggregate(dataTable, encoding),
     details = aggResult.details,
     hasDetails = details && details.length > 0,
     stack = hasDetails && compile.stack(spec, encoding, mdef, aggResult.facets);

--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -49,9 +49,10 @@ compile.encoding = function (encoding, stats) {
     mark = marks[encoding.marktype()],
     mdefs = marks.def(mark, encoding, layout, style),
     mdef = mdefs[0],  // TODO: remove this dirty hack by refactoring the whole flow
+    rawTable = spec.data[0],
     dataTable = spec.data[1];
 
-  filter.addFilters(spec, encoding);
+  filter.addFilters(rawTable, encoding);
   var sorting = compile.sort(spec.data, encoding, stats);
 
   var hasRow = encoding.has(ROW), hasCol = encoding.has(COL);
@@ -96,7 +97,7 @@ compile.encoding = function (encoding, stats) {
     group.legends = legend.defs(encoding);
   }
 
-  filter.filterLessThanZero(spec, encoding);
+  filter.filterLessThanZero(dataTable, encoding);
 
   return spec;
 };

--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -50,10 +50,10 @@ compile.encoding = function (encoding, stats) {
     dataTable = spec.data[1];
 
   rawTable = filter.addFilters(rawTable, encoding); // modify rawTable
-  var sorting = compile.sort(spec.data, encoding, stats); //modify spec.data
-  dataTable = compile.bin(dataTable, encoding); // modify dataTable
-  spec = compile.time(spec, encoding); // modify dataTable and add scales
-  var aggResult = compile.aggregate(dataTable, encoding); //modify dataTable
+  dataTable = compile.bin(dataTable, encoding);     // modify dataTable
+  spec = compile.time(spec, encoding);              // modify dataTable, add scales
+  var aggResult = compile.aggregate(dataTable, encoding); // modify dataTable
+  var sorting = compile.sort(spec.data, encoding, stats); // append new data
 
   // marks
   var style = compile.style(encoding, stats),

--- a/src/compile/filter.js
+++ b/src/compile/filter.js
@@ -28,6 +28,8 @@ filter.addFilters = function(spec, encoding) {
     var operator = filter.operator;
     var operands = filter.operands;
 
+    var d = 'd.data.';
+
     if (BINARY[operator]) {
       // expects a field and a value
       if (operator === '=') {
@@ -36,11 +38,11 @@ filter.addFilters = function(spec, encoding) {
 
       var op1 = operands[0];
       var op2 = operands[1];
-      condition = 'd.data.' + op1 + operator + op2;
+      condition = d + op1 + operator + op2;
     } else if (operator === 'notNull') {
       // expects a number of fields
       for (var j in operands) {
-        condition += 'd.data.' + operands[j] + '!==null';
+        condition += d + operands[j] + '!==null';
         if (j < operands.length - 1) {
           condition += ' && ';
         }

--- a/src/compile/filter.js
+++ b/src/compile/filter.js
@@ -13,12 +13,11 @@ var BINARY = {
   '<=': true
 };
 
-filter.addFilters = function(spec, encoding) {
-  var filters = encoding.filter(),
-    data = spec.data[0];  // apply filters to raw data before aggregation
+filter.addFilters = function(rawTable, encoding) {
+  var filters = encoding.filter();  // apply filters to raw data before aggregation
 
-  if (!data.transform)
-    data.transform = [];
+  if (!rawTable.transform)
+    rawTable.transform = [];
 
   // add custom filters
   for (var i in filters) {
@@ -51,7 +50,7 @@ filter.addFilters = function(spec, encoding) {
       console.warn('Unsupported operator: ', operator);
     }
 
-    data.transform.push({
+    rawTable.transform.push({
       type: 'filter',
       test: condition
     });
@@ -59,10 +58,10 @@ filter.addFilters = function(spec, encoding) {
 };
 
 // remove less than 0 values if we use log function
-filter.filterLessThanZero = function(spec, encoding) {
+filter.filterLessThanZero = function(dataTable, encoding) {
   encoding.forEach(function(field, encType) {
     if (encoding.scale(encType).type === 'log') {
-      spec.data[1].transform.push({
+      dataTable.transform.push({
         type: 'filter',
         test: 'd.' + encoding.field(encType) + '>0'
       });

--- a/src/compile/filter.js
+++ b/src/compile/filter.js
@@ -28,7 +28,7 @@ filter.addFilters = function(spec, encoding) {
     var operator = filter.operator;
     var operands = filter.operands;
 
-    var d = 'd.data.';
+    var d = 'd.' + (encoding._vega2 ? '' : 'data.');
 
     if (BINARY[operator]) {
       // expects a field and a value

--- a/src/compile/filter.js
+++ b/src/compile/filter.js
@@ -55,6 +55,8 @@ filter.addFilters = function(rawTable, encoding) {
       test: condition
     });
   }
+
+  return rawTable;
 };
 
 // remove less than 0 values if we use log function

--- a/src/compile/legend.js
+++ b/src/compile/legend.js
@@ -40,17 +40,17 @@ legend.defs = function(encoding) {
 };
 
 legend.def = function(name, encoding, props) {
-  var def = props, fn;
+  var def = props, timeUnit;
 
   def.title = encoding.fieldTitle(name);
 
-  if (encoding.isType(name, T) && (fn = encoding.fn(name)) &&
-    time.hasScale(fn)) {
+  if (encoding.isType(name, T) && (timeUnit = encoding.timeUnit(name)) &&
+    time.hasScale(timeUnit)) {
     var properties = def.properties = def.properties || {},
       labels = properties.labels = properties.labels || {},
       text = labels.text = labels.text || {};
 
-    text.scale = 'time-'+ fn;
+    text.scale = 'time-'+ timeUnit;
   }
 
   return def;

--- a/src/compile/scale.js
+++ b/src/compile/scale.js
@@ -39,8 +39,8 @@ scale.type = function(name, encoding) {
     case N: //fall through
     case O: return 'ordinal';
     case T:
-      var fn = encoding.fn(name);
-      return (fn && time.scale.type(fn, name)) || 'time';
+      var timeUnit = encoding.timeUnit(name);
+      return (timeUnit && time.scale.type(timeUnit, name)) || 'time';
     case Q:
       if (encoding.bin(name)) {
         return name === COLOR ? 'linear' : 'ordinal';
@@ -51,7 +51,7 @@ scale.type = function(name, encoding) {
 
 function scale_domain(name, encoding, sorting, opt) {
   if (encoding.isType(name, T)) {
-    var range = time.scale.domain(encoding.fn(name), name);
+    var range = time.scale.domain(encoding.timeUnit(name), name);
     if(range) return range;
   }
 
@@ -73,7 +73,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       } else {
         s.range = layout.cellWidth ? [0, layout.cellWidth] : 'width';
 
-        if (encoding.isType(s.name,T) && encoding.fn(s.name) === 'year') {
+        if (encoding.isType(s.name,T) && encoding.timeUnit(s.name) === 'year') {
           s.zero = false;
         } else {
           s.zero = spec.zero === undefined ? true : spec.zero;
@@ -83,7 +83,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       }
       s.round = true;
       if (s.type === 'time') {
-        s.nice = encoding.fn(s.name);
+        s.nice = encoding.timeUnit(s.name);
       }else {
         s.nice = true;
       }
@@ -94,7 +94,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       } else {
         s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
 
-        if (encoding.isType(s.name,T) && encoding.fn(s.name) === 'year') {
+        if (encoding.isType(s.name,T) && encoding.timeUnit(s.name) === 'year') {
           s.zero = false;
         } else {
           s.zero = spec.zero === undefined ? true : spec.zero;
@@ -106,7 +106,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       s.round = true;
 
       if (s.type === 'time') {
-        s.nice = encoding.fn(s.name) || encoding.config('timeScaleNice');
+        s.nice = encoding.timeUnit(s.name) || encoding.config('timeScaleNice');
       }else {
         s.nice = true;
       }

--- a/src/compile/scale.js
+++ b/src/compile/scale.js
@@ -62,7 +62,7 @@ scale.domain = function (name, encoding, sorting, opt) {
   if (name == opt.stack) {
     return {
       data: STACKED,
-      field: encoding.fieldName(name, {
+      field: encoding.fieldRef(name, {
         data: !encoding._vega2,
         fn: (opt.facet ? 'max_' : '') + 'sum'
       })

--- a/src/compile/scale.js
+++ b/src/compile/scale.js
@@ -21,10 +21,14 @@ scale.defs = function(names, encoding, layout, stats, style, sorting, opt) {
     var s = {
       name: name,
       type: scale.type(name, encoding),
-      domain: scale_domain(name, encoding, sorting, opt)
+      domain: scale.domain(name, encoding, sorting, opt)
     };
-    if (s.type === 'ordinal' && !encoding.bin(name) && encoding.sort(name).length === 0) {
+    if (s.type === 'ordinal' &&  // !encoding.bin(name) &&
+      encoding.sort(name).length === 0) {
       s.sort = true;
+      if (s.name === 'y') {
+        s.reverse = false;
+      }
     }
 
     scale_range(s, encoding, layout, stats, style, opt);
@@ -49,19 +53,24 @@ scale.type = function(name, encoding) {
   }
 };
 
-function scale_domain(name, encoding, sorting, opt) {
+scale.domain = function (name, encoding, sorting, opt) {
   if (encoding.isType(name, T)) {
     var range = time.scale.domain(encoding.timeUnit(name), name);
     if(range) return range;
   }
 
-  return name == opt.stack ?
-    {
+  if (name == opt.stack) {
+    return {
       data: STACKED,
-      field: 'data.' + (opt.facet ? 'max_' : '') + 'sum_' + encoding.field(name, true)
-    } :
-    {data: sorting.getDataset(name), field: encoding.field(name)};
-}
+      field: encoding.fieldName(name, {
+        data: !encoding._vega2,
+        fn: (opt.facet ? 'max_' : '') + 'sum'
+      })
+    };
+  }
+  return {data: sorting.getDataset(name), field: encoding.field(name)};
+};
+
 
 function scale_range(s, encoding, layout, stats, style, opt) {
   // jshint unused:false

--- a/src/compile/scale.js
+++ b/src/compile/scale.js
@@ -23,12 +23,8 @@ scale.defs = function(names, encoding, layout, stats, style, sorting, opt) {
       type: scale.type(name, encoding),
       domain: scale.domain(name, encoding, sorting, opt)
     };
-    if (s.type === 'ordinal' &&  // !encoding.bin(name) &&
-      encoding.sort(name).length === 0) {
+    if (s.type === 'ordinal' && !encoding.bin(name) && encoding.sort(name).length === 0) {
       s.sort = true;
-      if (s.name === 'y') {
-        s.reverse = false;
-      }
     }
 
     scale_range(s, encoding, layout, stats, style, opt);

--- a/src/compile/sort.js
+++ b/src/compile/sort.js
@@ -4,10 +4,10 @@ require('../globals');
 
 var vlfield = require('../field');
 
-module.exports = addSortTransforms;
+module.exports = addSortTransform;
 
 // adds new transforms that produce sorted fields
-function addSortTransforms(spec, encoding, stats, opt) {
+function addSortTransform(data, encoding, stats, opt) {
   // jshint unused:false
 
   var datasetMapping = {};
@@ -19,13 +19,13 @@ function addSortTransforms(spec, encoding, stats, opt) {
       var fields = sortBy.map(function(d) {
         return {
           op: d.aggregate,
-          field: vlfield.fieldName(d, {nofn: true, data: !encoding._vega2})
+          field: vlfield.fieldRef(d, {nofn: true, data: !encoding._vega2})
         };
       });
 
       var byClause = sortBy.map(function(d) {
         var reverse = (d.reverse ? '-' : '');
-        return reverse + 'data.' + (d.aggregate==='count' ? 'count' : (d.aggregate + '_' + d.name));
+        return reverse + vlfield.fieldRef(d, {data: !encoding._vega2});
       });
 
       var dataName = 'sorted' + counter++;
@@ -33,7 +33,7 @@ function addSortTransforms(spec, encoding, stats, opt) {
       var transforms = [
         {
           type: 'aggregate',
-          groupby: ['data.' + field.name],
+          groupby: [ encoding.fieldRef(encType) ],
           fields: fields
         },
         {
@@ -42,7 +42,7 @@ function addSortTransforms(spec, encoding, stats, opt) {
         }
       ];
 
-      spec.data.push({
+      data.push({
         name: dataName,
         source: RAW,
         transform: transforms
@@ -53,7 +53,6 @@ function addSortTransforms(spec, encoding, stats, opt) {
   });
 
   return {
-    spec: spec,
     getDataset: function(encType) {
       var data = datasetMapping[encType];
       if (!data) {
@@ -63,3 +62,4 @@ function addSortTransforms(spec, encoding, stats, opt) {
     }
   };
 }
+

--- a/src/compile/sort.js
+++ b/src/compile/sort.js
@@ -4,10 +4,10 @@ require('../globals');
 
 var vlfield = require('../field');
 
-module.exports = addSortTransform;
+module.exports = addSortTransforms;
 
 // adds new transforms that produce sorted fields
-function addSortTransform(data, encoding, stats, opt) {
+function addSortTransforms(data, encoding, stats, opt) {
   // jshint unused:false
 
   var datasetMapping = {};

--- a/src/compile/sort.js
+++ b/src/compile/sort.js
@@ -2,6 +2,8 @@
 
 require('../globals');
 
+var vlfield = require('../field');
+
 module.exports = addSortTransforms;
 
 // adds new transforms that produce sorted fields
@@ -17,7 +19,7 @@ function addSortTransforms(spec, encoding, stats, opt) {
       var fields = sortBy.map(function(d) {
         return {
           op: d.aggregate,
-          field: 'data.' + d.name
+          field: vlfield.fieldName(d, {nofn: true, data: !encoding._vega2})
         };
       });
 

--- a/src/compile/stack.js
+++ b/src/compile/stack.js
@@ -6,7 +6,7 @@ var  marks = require('./marks');
 
 module.exports = stacking;
 
-function stacking(spec, encoding, mdef, facets) {
+function stacking(data, encoding, mdef, facets) {
   if (!marks[encoding.marktype()].stack) return false;
 
   // TODO: add || encoding.has(LOD) here once LOD is implemented
@@ -50,7 +50,7 @@ function stacking(spec, encoding, mdef, facets) {
     });
   }
 
-  spec.data.push(stacked);
+  data.push(stacked);
 
   // add stack transform to mark
   mdef.from.transform = [{

--- a/src/compile/stack.js
+++ b/src/compile/stack.js
@@ -43,7 +43,10 @@ function stacking(spec, encoding, mdef, facets) {
     stacked.transform.push({ //calculate max for each facet
       type: 'aggregate',
       groupby: facets,
-      fields: [{op: 'max', field: 'data.sum_' + encoding.field(val, true)}]
+      fields: [{
+        op: 'max',
+        field: encoding.fieldName(val, {fn: 'sum'})
+      }]
     });
   }
 

--- a/src/compile/time.js
+++ b/src/compile/time.js
@@ -4,7 +4,7 @@ var util = require('../util');
 
 module.exports = time;
 
-function time(spec, encoding, opt) {
+function time(spec, encoding, opt) { // FIXME refactor to reduce side effect #276
   // jshint unused:false
   var timeFields = {}, timeUnits = {};
 
@@ -35,6 +35,8 @@ function time(spec, encoding, opt) {
   }
   return spec;
 }
+
+
 
 time.cardinality = function(field, stats, filterNull, type) {
   var timeUnit = field.timeUnit;

--- a/src/field.js
+++ b/src/field.js
@@ -15,7 +15,7 @@ var vlfield = module.exports = {};
 vlfield.shorthand = function(f) {
   var c = consts.shorthand;
   return (f.aggregate ? f.aggregate + c.func : '') +
-    (f.fn ? f.fn + c.func : '') +
+    (f.timeUnit ? f.timeUnit + c.func : '') +
     (f.bin ? 'bin' + c.func : '') +
     (f.name || '') + c.type + f.type;
 };
@@ -43,12 +43,12 @@ vlfield.fromShorthand = function(shorthand) {
     }
   }
 
-  // check time fn
+  // check time timeUnit
   for (i in schema.timefns) {
-    var f = schema.timefns[i];
-    if (o.name && o.name.indexOf(f + '_') === 0) {
+    var tu = schema.timefns[i];
+    if (o.name && o.name.indexOf(tu + '_') === 0) {
       o.name = o.name.substr(o.length + 1);
-      o.fn = f;
+      o.timeUnit = tu;
       break;
     }
   }
@@ -110,12 +110,12 @@ var isTypes = vlfield.isTypes = function (fieldDef, types) {
  */
 vlfield.isOrdinalScale = function(field) {
   return  isTypes(field, [N, O]) || field.bin ||
-    ( isType(field, T) && field.fn && time.isOrdinalFn(field.fn) );
+    ( isType(field, T) && field.timeUnit && time.isOrdinalFn(field.timeUnit) );
 };
 
 function isDimension(field) {
   return  isTypes(field, [N, O]) || !!field.bin ||
-    ( isType(field, T) && !!field.fn );
+    ( isType(field, T) && !!field.timeUnit );
 }
 
 /**

--- a/src/field.js
+++ b/src/field.js
@@ -12,16 +12,19 @@ var consts = require('./consts'),
 
 var vlfield = module.exports = {};
 
-vlfield.field = function(field, nofn, nodata) {
-  var f = (nodata || this._vega2 ? '' : 'data.');
+vlfield.fieldName = function(field, opt) {
+  var f = (opt.data ? 'data.' : '');
+
   if (vlfield.isCount(field)) {
     return f + 'count';
-  } else if (!nofn && field.bin) {
+  } else if (!opt.nofn && field.bin) {
     return f + 'bin_' + field.name;
-  } else if (!nofn && field.aggregate) {
+  } else if (!opt.nofn && field.aggregate) {
     return f + field.aggregate + '_' + field.name;
-  } else if (!nofn && field.timeUnit) {
+  } else if (!opt.nofn && field.timeUnit) {
     return f + field.timeUnit + '_' + field.name;
+  } else if (opt.fn) {
+    return f + opt.fn + field.name;
   } else {
     return f + field.name;
   }

--- a/src/field.js
+++ b/src/field.js
@@ -12,19 +12,28 @@ var consts = require('./consts'),
 
 var vlfield = module.exports = {};
 
+/**
+ * @param field
+ * @param opt
+ *   opt.nofn -- exclude bin, aggregate, timeUnit
+ *   opt.fn - custom function prefix
+ *   opt.data - include 'data.'
+ * @return {[type]}       [description]
+ */
 vlfield.fieldName = function(field, opt) {
-  var f = (opt.data ? 'data.' : '');
+  var f = (opt.data ? 'data.' : ''),
+    nofn = opt.nofn || opt.fn;
 
   if (vlfield.isCount(field)) {
     return f + 'count';
-  } else if (!opt.nofn && field.bin) {
+  } else if (!nofn && field.bin) {
     return f + 'bin_' + field.name;
-  } else if (!opt.nofn && field.aggregate) {
+  } else if (!nofn && field.aggregate) {
     return f + field.aggregate + '_' + field.name;
-  } else if (!opt.nofn && field.timeUnit) {
+  } else if (!nofn && field.timeUnit) {
     return f + field.timeUnit + '_' + field.name;
   } else if (opt.fn) {
-    return f + opt.fn + field.name;
+    return f + opt.fn + '_' + field.name;
   } else {
     return f + field.name;
   }

--- a/src/field.js
+++ b/src/field.js
@@ -12,6 +12,21 @@ var consts = require('./consts'),
 
 var vlfield = module.exports = {};
 
+vlfield.field = function(field, nofn, nodata) {
+  var f = (nodata || this._vega2 ? '' : 'data.');
+  if (vlfield.isCount(field)) {
+    return f + 'count';
+  } else if (!nofn && field.bin) {
+    return f + 'bin_' + field.name;
+  } else if (!nofn && field.aggregate) {
+    return f + field.aggregate + '_' + field.name;
+  } else if (!nofn && field.timeUnit) {
+    return f + field.timeUnit + '_' + field.name;
+  } else {
+    return f + field.name;
+  }
+};
+
 vlfield.shorthand = function(f) {
   var c = consts.shorthand;
   return (f.aggregate ? f.aggregate + c.func : '') +

--- a/src/field.js
+++ b/src/field.js
@@ -16,26 +16,30 @@ var vlfield = module.exports = {};
  * @param field
  * @param opt
  *   opt.nofn -- exclude bin, aggregate, timeUnit
- *   opt.fn - custom function prefix
  *   opt.data - include 'data.'
+ *   opt.fn - custom function prefix
+
  * @return {[type]}       [description]
  */
-vlfield.fieldName = function(field, opt) {
+vlfield.fieldRef = function(field, opt) {
+  opt = opt || {};
+
   var f = (opt.data ? 'data.' : ''),
-    nofn = opt.nofn || opt.fn;
+    nofn = opt.nofn || opt.fn,
+    name = field.name;
 
   if (vlfield.isCount(field)) {
     return f + 'count';
   } else if (!nofn && field.bin) {
-    return f + 'bin_' + field.name;
+    return f + 'bin_' + name;
   } else if (!nofn && field.aggregate) {
-    return f + field.aggregate + '_' + field.name;
+    return f + field.aggregate + '_' + name;
   } else if (!nofn && field.timeUnit) {
-    return f + field.timeUnit + '_' + field.name;
+    return f + field.timeUnit + '_' + name;
   } else if (opt.fn) {
-    return f + opt.fn + '_' + field.name;
+    return f + opt.fn + '_' + name;
   } else {
-    return f + field.name;
+    return f + name;
   }
 };
 

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -46,13 +46,13 @@ schema.getSupportedRole = function(encType) {
   return schema.schema.properties.encoding.properties[encType].supportedRole;
 };
 
-schema.timefns = ['year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds'];
+schema.timeUnits = ['year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds'];
 
 schema.defaultTimeFn = 'month';
 
 schema.timeUnit = {
   type: 'string',
-  enum: schema.timefns,
+  enum: schema.timeUnits,
   supportedTypes: toMap([T])
 };
 

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -50,7 +50,7 @@ schema.timefns = ['year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds']
 
 schema.defaultTimeFn = 'month';
 
-schema.fn = {
+schema.timeUnit = {
   type: 'string',
   enum: schema.timefns,
   supportedTypes: toMap([T])
@@ -100,7 +100,7 @@ var typicalField = merge(clone(schema.field), {
       enum: [N, O, Q, T]
     },
     aggregate: schema.aggregate,
-    fn: schema.fn,
+    timeUnit: schema.timeUnit,
     bin: bin,
     scale: {
       type: 'object',
@@ -135,9 +135,9 @@ var onlyOrdinalField = merge(clone(schema.field), {
   properties: {
     type: {
       type: 'string',
-      enum: [N, O, Q, T] // ordinal-only field supports Q when bin is applied and T when fn is applied.
+      enum: [N, O, Q, T] // ordinal-only field supports Q when bin is applied and T when time unit is applied.
     },
-    fn: schema.fn,
+    timeUnit: schema.timeUnit,
     bin: bin,
     aggregate: {
       type: 'string',

--- a/test/compile/aggregate.spec.js
+++ b/test/compile/aggregate.spec.js
@@ -1,0 +1,40 @@
+var expect = require('chai').expect;
+
+var aggregate = require('../../src/compile/aggregate'),
+  Encoding = require('../../src/Encoding');
+
+describe('vl.compile.aggregate', function() {
+  it('return correct aggregation', function() {
+    var dataTable = {
+        name: TABLE,
+        source: RAW
+      },
+      spec = {
+        encoding: {
+          'y': {
+            'aggregate': 'sum',
+            'name': 'Acceleration',
+            'type': 'Q'
+          },
+          'x': {
+            'name': 'origin',
+            "type": "O"
+          },
+        }
+      };
+
+    aggregate(dataTable, Encoding.fromSpec(spec));
+    expect(dataTable).to.eql({
+      "name": "table",
+      "source": "raw",
+      "transform": [{
+        "type": "aggregate",
+        "groupby": ["data.origin"],
+        "fields": [{
+          "op": "sum",
+          "field": "data.Acceleration"
+        }]
+      }]
+    });
+  });
+});

--- a/test/compile/axis.spec.js
+++ b/test/compile/axis.spec.js
@@ -26,6 +26,9 @@ describe('Axis', function() {
         axisTitleOffset: 60
       }
     });
+
+    //FIXME decouple the test here
+
     it('should use custom label', function() {
       expect(_axis.properties.labels.text.scale).to.equal('time-'+ timeUnit);
     });

--- a/test/compile/axis.spec.js
+++ b/test/compile/axis.spec.js
@@ -8,10 +8,10 @@ var axis = require('../../src/compile/axis'),
 describe('Axis', function() {
   describe('(X) for Time Data', function() {
     var fieldName = 'a',
-      fn = 'month',
+      timeUnit = 'month',
       encoding = Encoding.fromSpec({
         encoding: {
-          x: {name: fieldName, type: 'T', fn: fn}
+          x: {name: fieldName, type: 'T', timeUnit: timeUnit}
         }
       });
     var _axis = axis.def('x', encoding, {
@@ -27,7 +27,7 @@ describe('Axis', function() {
       }
     });
     it('should use custom label', function() {
-      expect(_axis.properties.labels.text.scale).to.equal('time-'+ fn);
+      expect(_axis.properties.labels.text.scale).to.equal('time-'+ timeUnit);
     });
     it('should rotate label', function() {
       expect(_axis.properties.labels.angle.value).to.equal(270);

--- a/test/compile/bin.spec.js
+++ b/test/compile/bin.spec.js
@@ -1,0 +1,31 @@
+var expect = require('chai').expect;
+
+var bin = require('../../src/compile/bin'),
+  Encoding = require('../../src/Encoding');
+
+describe('vl.compile.bin', function() {
+  it('return correct bin', function() {
+    var dataTable = {name: TABLE, source: RAW},
+      spec = {
+        encoding: {
+          'y': {
+            'bin': {'maxbins': 15},
+            'name': 'Acceleration',
+            'type': 'Q'
+          }
+        }
+      };
+
+    bin(dataTable, Encoding.fromSpec(spec));
+    expect(dataTable).to.eql({
+      name: 'table',
+      source: 'raw',
+      transform: [{
+        type: 'bin',
+        field: 'data.Acceleration',
+        output: 'data.bin_Acceleration',
+        maxbins: 15
+      }]
+    });
+  });
+});

--- a/test/compile/marks.spec.js
+++ b/test/compile/marks.spec.js
@@ -69,6 +69,7 @@ describe('compile.marks', function() {
         });
       });
     });
-
   });
+
+  // TODO add other type of marks
 });

--- a/test/compile/scale.spec.js
+++ b/test/compile/scale.spec.js
@@ -1,25 +1,46 @@
 'use strict';
 
-var d3= require('d3');
+var d3 = require('d3');
 var expect = require('chai').expect;
 
 var util = require('../../src/util'),
+  Encoding = require('../../src/Encoding'),
   vlscale = require('../../src/compile/scale'),
   colorbrewer = require('../../src/lib/colorbrewer/colorbrewer');
 
+describe('vl.compile.scale.domain', function() {
+  it('should return correct stack', function() {
+    var scale = vlscale.domain('y', Encoding.fromSpec({
+      encoding: {
+        y: {
+          name: 'origin'
+        }
+      }
+    }), {}, {
+      stack: 'y',
+      facet: true
+    });
 
+    expect(scale).to.eql({
+      data: 'stacked',
+      field: 'data.max_sum_origin'
+    });
+  });
+});
 
-describe('vl.scale.color.palette', function() {
+describe('vl.compile.scale.color.palette', function() {
   it('should return tableau categories', function() {
     expect(vlscale.color.palette('category10k')).to.eql(
-      ['#2ca02c', '#e377c2', '#7f7f7f', '#17becf', '#8c564b', '#d62728', '#bcbd22', '#9467bd', '#ff7f0e', '#1f77b4']
+      ['#2ca02c', '#e377c2', '#7f7f7f', '#17becf', '#8c564b', '#d62728', '#bcbd22',
+        '#9467bd', '#ff7f0e', '#1f77b4'
+      ]
     );
   });
 
   it('should return pre-defined brewer palette if low cardinality', function() {
     var brewerPalettes = util.keys(colorbrewer);
     brewerPalettes.forEach(function(palette) {
-      util.range(3,9).forEach(function(cardinality) {
+      util.range(3, 9).forEach(function(cardinality) {
         expect(vlscale.color.palette(palette, cardinality)).to.eql(
           colorbrewer[palette][cardinality]
         );
@@ -43,22 +64,26 @@ describe('vl.scale.color.palette', function() {
       var cardinality = 20,
         ps = 5,
         p = colorbrewer[palette],
-        interpolator = d3.interpolateLab(p[ps][0], p[ps][ps-1]);
+        interpolator = d3.interpolateLab(p[ps][0], p[ps][ps - 1]);
       expect(vlscale.color.palette(palette, cardinality, 'O')).to.eql(
-        util.range(cardinality).map(function(i) { return interpolator(i*1.0/(cardinality-1)); })
+        util.range(cardinality).map(function(i) {
+          return interpolator(i * 1.0 / (cardinality - 1));
+        })
       );
     });
   });
 });
 
-describe('vl.scale.color.interpolate', function() {
+describe('vl.compile.scale.color.interpolate', function() {
   it('should interpolate color along the lab space', function() {
-    var interpolator = d3.interpolateLab('#ffffff','#000000'),
+    var interpolator = d3.interpolateLab('#ffffff', '#000000'),
       cardinality = 8;
 
-    expect(vlscale.color.interpolate('#ffffff','#000000', cardinality))
+    expect(vlscale.color.interpolate('#ffffff', '#000000', cardinality))
       .to.eql(
-        util.range(cardinality).map(function(i) { return interpolator(i*1.0/(cardinality-1)); })
+        util.range(cardinality).map(function(i) {
+          return interpolator(i * 1.0 / (cardinality - 1));
+        })
       );
   });
 });

--- a/test/compile/scale.spec.js
+++ b/test/compile/scale.spec.js
@@ -26,6 +26,8 @@ describe('vl.compile.scale.domain', function() {
       field: 'data.max_sum_origin'
     });
   });
+
+  // TODO test other cases
 });
 
 describe('vl.compile.scale.color.palette', function() {

--- a/test/compile/sort.spec.js
+++ b/test/compile/sort.spec.js
@@ -19,13 +19,13 @@ describe('Sort', function() {
           }]}
         }
       }),
-    sorting = vlsort({data: [{name: RAW}, {name: TABLE}]}, encoding, {}),
-    spec = sorting.spec;
+    data = [{name: RAW}, {name: TABLE}],
+    sorting = vlsort(data, encoding, {});
 
   it('should add new data and transform', function() {
-    expect(spec.data.length).to.equal(4);
+    expect(data.length).to.equal(4);
 
-    expect(spec.data[2].transform).to.deep.equal([
+    expect(data[2].transform).to.deep.equal([
       {
         type: 'aggregate',
         groupby: [ 'data.foo' ],
@@ -37,7 +37,7 @@ describe('Sort', function() {
       { type: 'sort', by: [ 'data.avg_bar' ] }
     ]);
 
-    expect(spec.data[3].transform).to.deep.equal([
+    expect(data[3].transform).to.deep.equal([
       {
         type: 'aggregate',
         groupby: [ 'data.baz' ],

--- a/test/compile/stack.spec.js
+++ b/test/compile/stack.spec.js
@@ -38,6 +38,7 @@ describe('vl.compile.stack()', function () {
 
   describe('bin-x', function () {
     it('should put stack on y', function () {
+      // FIXME don't run the whole compile
       var vgSpec = compile(fixtures.binX, stats);
 
       var tableData = vgSpec.data.filter(function(data) {
@@ -62,6 +63,7 @@ describe('vl.compile.stack()', function () {
 
   describe('bin-y', function () {
     it('should put stack on x', function () {
+      // FIXME don't run the whole compile
       var vgSpec = compile(fixtures.binY, stats);
 
       var tableData = vgSpec.data.filter(function(data) {

--- a/test/compile/time.spec.js
+++ b/test/compile/time.spec.js
@@ -7,10 +7,10 @@ var time = require('../../src/compile/time'),
 
 describe('Time', function() {
   var fieldName = 'a',
-    fn = 'month',
+    timeUnit = 'month',
     encoding = Encoding.fromSpec({
       encoding: {
-        x: {name: fieldName, type: 'T', fn: fn}
+        x: {name: fieldName, type: 'T', timeUnit: timeUnit}
       }
     }),
     spec = time({data: [{name: RAW}, {name: TABLE}]}, encoding, {});
@@ -27,7 +27,7 @@ describe('Time', function() {
 
   it('should add custom axis scale', function() {
     expect(spec.scales.filter(function(scale) {
-      return scale.name == 'time-'+ fn;
+      return scale.name == 'time-'+ timeUnit;
     }).length).to.equal(1);
   });
 });


### PR DESCRIPTION
- remove `’.data’` and rely on `vl.field.fieldRef`
- stop throwing the whole `spec` around in `compile.js`
- re-order/re-group `compile.js` (so we can decouple things in the next PR)
- add some more tests

A small step toward #276 and preparing for #459 

Note that a `encoding._vega2` flag will be introduced during the transition (and eliminated entirely after the migration).  

**Please merge #457 first**