### PR TITLE
Fixed array iteration bug

### DIFF
--- a/src/compiler/filter.js
+++ b/src/compiler/filter.js
@@ -21,39 +21,43 @@ filter.addFilters = function(rawTable, encoding) {
 
   // add custom filters
   for (var i in filters) {
-    var filter = filters[i];
+    if(filters.hasOwnProperty(filters[i])) {
+      var filter = filters[i];
 
-    var condition = '';
-    var operator = filter.operator;
-    var operands = filter.operands;
+      var condition = '';
+      var operator = filter.operator;
+      var operands = filter.operands;
 
-    var d = 'd.' + (encoding._vega2 ? '' : 'data.');
+      var d = 'd.' + (encoding._vega2 ? '' : 'data.');
 
-    if (BINARY[operator]) {
-      // expects a field and a value
-      if (operator === '=') {
-        operator = '==';
-      }
-
-      var op1 = operands[0];
-      var op2 = operands[1];
-      condition = d + op1 + operator + op2;
-    } else if (operator === 'notNull') {
-      // expects a number of fields
-      for (var j in operands) {
-        condition += d + operands[j] + '!==null';
-        if (j < operands.length - 1) {
-          condition += ' && ';
+      if (BINARY[operator]) {
+        // expects a field and a value
+        if (operator === '=') {
+          operator = '==';
         }
-      }
-    } else {
-      console.warn('Unsupported operator: ', operator);
-    }
 
-    rawTable.transform.push({
-      type: 'filter',
-      test: condition
-    });
+        var op1 = operands[0];
+        var op2 = operands[1];
+        condition = d + op1 + operator + op2;
+      } else if (operator === 'notNull') {
+        // expects a number of fields
+        for (var j in operands) {
+          if(operands.hasOwnProperty(operands[j])) {
+            condition += d + operands[j] + '!==null';
+            if (j < operands.length - 1) {
+              condition += ' && ';
+            }
+          }
+        }
+      } else {
+        console.warn('Unsupported operator: ', operator);
+      }
+
+      rawTable.transform.push({
+        type: 'filter',
+        test: condition
+      });
+    }
   }
 
   return rawTable;


### PR DESCRIPTION
Faced an issue with array iteration while using vega-lite inside an Ember.js project. 

The code below iterates all the properties attached to an array like "_super", "contains", "getEach" etc.

```javascript
for (var i in filters) {
  ...
}
```

Fixed it by checking if the property is the array's own property using "hasOwnProperty()" method.