### PR TITLE
remove bogus `grid` property in `rowMixIn`

### DIFF
--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -345,12 +345,7 @@ var rowMixin = {
       type: 'number',
       minimum: 0,
       default: 150
-    },
-    grid: {
-      type: 'boolean',
-      default: true,
-      description: 'A flag indicate if gridlines should be created in addition to ticks.'
-    },
+    }
   }
 };
 


### PR DESCRIPTION
Revising the code, I just realized that this `grid` property hasn’t been used at all.

Both `ROW` and `COL` already include `axisMixins`, so these few lines are bogus.