### PR TITLE
Feeding scale with raw data for supporting aligning axis with same domain 

### DIFF
--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -197,7 +197,7 @@ function point_props(e, layout, style) {
   }
 
   // stroke
-  if (e.enc(SHAPE).filled) {
+  if (e.field(SHAPE).filled) {
     if (e.has(COLOR)) {
       p.fill = {scale: COLOR, field: e.field(COLOR)};
     } else if (!e.has(COLOR)) {

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -221,8 +221,6 @@ function point_props(e, layout, style) {
     p.opacity = {value: style.opacity};
   }
 
-
-
   return p;
 }
 

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -65,13 +65,17 @@ scale.domain = function (name, encoding, sorting, opt) {
     };
   }
 
-  var aggregate = encoding.aggregate(name);
+  var aggregate = encoding.aggregate(name),
+    timeUnit = encoding.timeUnit(name);
+
 
   if (
     encoding.scale(name).useRawDomain &&
-    aggregate && aggregate !=='count' &&
-    !encoding.bin(name) &&
-    encoding.isType(name, Q)
+    (aggregate && aggregate !=='count') &&
+    // Q always use non-ordinal scale except when it's binned and thus uses ordinal scale.
+    (encoding.isType(name, Q) && !encoding.bin(name))
+    // T use non-ordinal scale when there's no unit or when the unit is not ordinal.
+    (encoding.isType(name, T) && (!timeUnit || !time.isOrdinalFn(timeUnit)))
   ) {
     return {data: RAW, field: encoding.fieldRef(name, {nofn: true})};
   }

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -64,6 +64,17 @@ scale.domain = function (name, encoding, sorting, opt) {
       })
     };
   }
+
+  var aggregate = encoding.aggregate(name);
+
+  if (
+    aggregate && aggregate !=='count' &&
+    !encoding.bin(name) &&
+    encoding.isType(name, Q)
+  ) {
+    return {data: RAW, field: encoding.fieldRef(name, {nofn: true})};
+  }
+
   return {data: sorting.getDataset(name), field: encoding.field(name)};
 };
 

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -68,6 +68,7 @@ scale.domain = function (name, encoding, sorting, opt) {
   var aggregate = encoding.aggregate(name);
 
   if (
+    encoding.scale(name).useRawDomain &&
     aggregate && aggregate !=='count' &&
     !encoding.bin(name) &&
     encoding.isType(name, Q)

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -70,9 +70,9 @@ scale.domain = function (name, encoding, sorting, opt) {
     notCountOrSum = !aggregate || (aggregate !=='count' && aggregate !== 'sum');
 
   if ( useRawDomain && notCountOrSum && (
-      // Q always use non-ordinal scale except when it's binned and thus uses ordinal scale.
+      // Q always uses non-ordinal scale except when it's binned and thus uses ordinal scale.
       (encoding.isType(name, Q) && !encoding.bin(name)) ||
-      // T use non-ordinal scale when there's no unit or when the unit is not ordinal.
+      // T uses non-ordinal scale when there's no unit or when the unit is not ordinal.
       (encoding.isType(name, T) && (!timeUnit || !time.isOrdinalFn(timeUnit)))
     )
   ) {

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -66,16 +66,16 @@ scale.domain = function (name, encoding, sorting, opt) {
   }
 
   var aggregate = encoding.aggregate(name),
-    timeUnit = encoding.timeUnit(name);
+    timeUnit = encoding.timeUnit(name),
+    useRawDomain = encoding.scale(name).useRawDomain,
+    notCount = !aggregate || (aggregate !=='count');
 
-
-  if (
-    encoding.scale(name).useRawDomain &&
-    (aggregate && aggregate !=='count') &&
-    // Q always use non-ordinal scale except when it's binned and thus uses ordinal scale.
-    (encoding.isType(name, Q) && !encoding.bin(name))
-    // T use non-ordinal scale when there's no unit or when the unit is not ordinal.
-    (encoding.isType(name, T) && (!timeUnit || !time.isOrdinalFn(timeUnit)))
+  if ( useRawDomain && notCount && (
+      // Q always use non-ordinal scale except when it's binned and thus uses ordinal scale.
+      (encoding.isType(name, Q) && !encoding.bin(name)) ||
+      // T use non-ordinal scale when there's no unit or when the unit is not ordinal.
+      (encoding.isType(name, T) && (!timeUnit || !time.isOrdinalFn(timeUnit)))
+    )
   ) {
     return {data: RAW, field: encoding.fieldRef(name, {nofn: true})};
   }

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -67,9 +67,9 @@ scale.domain = function (name, encoding, sorting, opt) {
   var aggregate = encoding.aggregate(name),
     timeUnit = encoding.field(name).timeUnit,
     useRawDomain = encoding.scale(name).useRawDomain,
-    notCount = !aggregate || (aggregate !=='count');
+    notCountOrSum = !aggregate || (aggregate !=='count' && aggregate !== 'sum');
 
-  if ( useRawDomain && notCount && (
+  if ( useRawDomain && notCountOrSum && (
       // Q always use non-ordinal scale except when it's binned and thus uses ordinal scale.
       (encoding.isType(name, Q) && !encoding.bin(name)) ||
       // T use non-ordinal scale when there's no unit or when the unit is not ordinal.

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -179,6 +179,11 @@ var axisMixin = {
           default: 25,
           minimum: 0,
           description: 'Truncate labels that are too long.'
+        },
+        useRawDomain: {
+          type: 'boolean',
+          default: false,
+          description: 'Use the raw data range as scale domain instead of aggregated data for aggregate axis.'
         }
       }
     }

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -121,6 +121,11 @@ var typicalField = merge(clone(schema.field), {
           type: 'string',
           enum: ['second', 'minute', 'hour', 'day', 'week', 'month', 'year'],
           supportedTypes: toMap([T])
+        },
+        useRawDomain: {
+          type: 'boolean',
+          default: false,
+          description: 'Use the raw data range as scale domain instead of aggregated data for aggregate axis.'
         }
       }
     }
@@ -179,11 +184,6 @@ var axisMixin = {
           default: 25,
           minimum: 0,
           description: 'Truncate labels that are too long.'
-        },
-        useRawDomain: {
-          type: 'boolean',
-          default: false,
-          description: 'Use the raw data range as scale domain instead of aggregated data for aggregate axis.'
         }
       }
     }

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -114,7 +114,7 @@ var typicalField = merge(clone(schema.field), {
           description: 'Use the raw data range as scale domain instead of ' +
                        'aggregated data for aggregate axis. ' +
                        'This option does not work with sum or count aggregate' +
-                       'as they might have substantially large scale range.'
+                       'as they might have a substantially larger scale range.'
         }
       }
     }

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -111,7 +111,10 @@ var typicalField = merge(clone(schema.field), {
         useRawDomain: {
           type: 'boolean',
           default: false,
-          description: 'Use the raw data range as scale domain instead of aggregated data for aggregate axis.'
+          description: 'Use the raw data range as scale domain instead of ' +
+                       'aggregated data for aggregate axis. ' +
+                       'This option does not work with sum or count aggregate' +
+                       'as they might have substantially large scale range.'
         }
       }
     }

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -8,9 +8,14 @@ var util = require('../../src/util'),
   vlscale = require('../../src/compiler/scale'),
   colorbrewer = require('colorbrewer');
 
-describe('vl.compile.scale.domain', function() {
+describe('vl.compile.scale.domain()', function() {
+  var sortingReturn = 'sorted',
+    sorting = {
+      getDataset: function() {return 'sorted';}
+    };
+
   it('should return correct stack', function() {
-    var scale = vlscale.domain('y', Encoding.fromSpec({
+    var domain = vlscale.domain('y', Encoding.fromSpec({
       encoding: {
         y: {
           name: 'origin'
@@ -21,14 +26,14 @@ describe('vl.compile.scale.domain', function() {
       facet: true
     });
 
-    expect(scale).to.eql({
+    expect(domain).to.eql({
       data: 'stacked',
       field: 'data.max_sum_origin'
     });
   });
 
   it('should return correct aggregated stack', function() {
-    var scale = vlscale.domain('y', Encoding.fromSpec({
+    var domain = vlscale.domain('y', Encoding.fromSpec({
       encoding: {
         y: {
           aggregate: 'sum',
@@ -40,10 +45,106 @@ describe('vl.compile.scale.domain', function() {
       facet: true
     });
 
-    expect(scale).to.eql({
+    expect(domain).to.eql({
       data: 'stacked',
       field: 'data.max_sum_sum_origin'
     });
+  });
+
+  it('should return the right domain if binned Q',
+    function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            bin: true,
+            name: 'origin',
+            scale: {useRawDomain: true},
+            type: Q
+          }
+        }
+      }), sorting, {});
+
+      expect(domain.data).to.eql(sortingReturn);
+    });
+
+
+  it('should return the raw domain if useRawDomain is true for non-binned Q',
+    function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            aggregate: 'sum',
+            name: 'origin',
+            scale: {useRawDomain: true},
+            type: Q
+          }
+        }
+      }), {}, {});
+
+      expect(domain.data).to.eql(RAW);
+    });
+
+  it('should return the raw domain if useRawDomain is true for raw T',
+    function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            name: 'origin',
+            scale: {useRawDomain: true},
+            type: T
+          }
+        }
+      }), {}, {});
+
+      expect(domain.data).to.eql(RAW);
+    });
+
+
+  it('should return the raw domain if useRawDomain is true for year T',
+    function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            name: 'origin',
+            scale: {useRawDomain: true},
+            type: T,
+            timeUnit: 'year'
+          }
+        }
+      }), {}, {});
+
+      expect(domain.data).to.eql(RAW);
+    });
+
+  it('should return the correct domain for month T',
+    function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            name: 'origin',
+            scale: {useRawDomain: true},
+            type: T,
+            timeUnit: 'month'
+          }
+        }
+      }), sorting, {});
+
+      expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    });
+
+  it('should return the aggregated domain if useRawDomain is false', function() {
+    var domain = vlscale.domain('y', Encoding.fromSpec({
+      encoding: {
+        y: {
+          aggregate: 'sum',
+          name: 'origin',
+          scale: {useRawDomain: false},
+          type: Q
+        }
+      }
+    }), sorting, {});
+
+    expect(domain.data).to.eql(sortingReturn);
   });
 
   // TODO test other cases

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -67,8 +67,23 @@ describe('vl.compile.scale.domain()', function() {
       expect(domain.data).to.eql(sortingReturn);
     });
 
+  it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
+    function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            aggregate: 'mean',
+            name: 'origin',
+            scale: {useRawDomain: true},
+            type: Q
+          }
+        }
+      }), {}, {});
 
-  it('should return the raw domain if useRawDomain is true for non-binned Q',
+      expect(domain.data).to.eql(RAW);
+    });
+
+  it('should return the aggregate domain for sum Q',
     function() {
       var domain = vlscale.domain('y', Encoding.fromSpec({
         encoding: {
@@ -79,9 +94,9 @@ describe('vl.compile.scale.domain()', function() {
             type: Q
           }
         }
-      }), {}, {});
+      }), sorting, {});
 
-      expect(domain.data).to.eql(RAW);
+      expect(domain.data).to.eql(sortingReturn);
     });
 
   it('should return the raw domain if useRawDomain is true for raw T',
@@ -98,7 +113,6 @@ describe('vl.compile.scale.domain()', function() {
 
       expect(domain.data).to.eql(RAW);
     });
-
 
   it('should return the raw domain if useRawDomain is true for year T',
     function() {
@@ -136,7 +150,7 @@ describe('vl.compile.scale.domain()', function() {
     var domain = vlscale.domain('y', Encoding.fromSpec({
       encoding: {
         y: {
-          aggregate: 'sum',
+          aggregate: 'min',
           name: 'origin',
           scale: {useRawDomain: false},
           type: Q


### PR DESCRIPTION
fixes #475 

To support reading across chart in Voyager, we need an option to use RAW table as the data source for a scale’s domain.  

**TODO**
- [x] Unit Tests

Should we find some way to align scale for `COUNT` 