### PR TITLE
Eliminate redundant help in encoding.

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -190,10 +190,6 @@ module.exports = (function() {
     return this._enc[et].value;
   };
 
-  proto.timeUnit = function(et) {
-    return this._enc[et].timeUnit;
-  };
-
   proto.sort = function(et, stats) {
     var sort = this._enc[et].sort,
       enc = this._enc,

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -159,10 +159,6 @@ module.exports = (function() {
     return this._enc[et].axis || {};
   };
 
-  proto.band = function(et) {
-    return this._enc[et].band || {};
-  };
-
   proto.bandSize = function(encType, useSmallBand) {
     useSmallBand = useSmallBand ||
       //isBandInSmallMultiples
@@ -170,7 +166,7 @@ module.exports = (function() {
       (encType === X && this.has(COL) && this.has(X));
 
     // if band.size is explicitly specified, follow the specification, otherwise draw value from config.
-    return this.band(encType).size ||
+    return this.field(encType).band.size ||
       this.config(useSmallBand ? 'smallBandSize' : 'largeBandSize');
   };
 

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -159,9 +159,9 @@ function axis_title(def, name, encoding, layout, opt) {
 function axis_labels(def, name, encoding, layout, opt) {
   // jshint unused:false
 
-  var timeUnit;
+  var timeUnit = encoding.field(name).timeUnit;
   // add custom label for time type
-  if (encoding.isType(name, T) && (timeUnit = encoding.timeUnit(name)) && (time.hasScale(timeUnit))) {
+  if (encoding.isType(name, T) && timeUnit && (time.hasScale(timeUnit))) {
     setter(def, ['properties','labels','text','scale'], 'time-'+ timeUnit);
   }
 
@@ -171,9 +171,9 @@ function axis_labels(def, name, encoding, layout, opt) {
   } else if (encoding.isType(name, Q)) {
     setter(def, textTemplatePath, '{{data | number:\'.3s\'}}');
   } else if (encoding.isType(name, T)) {
-    if (!encoding.timeUnit(name)) {
+    if (!timeUnit) {
       setter(def, textTemplatePath, '{{data | time:\'%Y-%m-%d\'}}');
-    } else if (encoding.timeUnit(name) === 'year') {
+    } else if (timeUnit === 'year') {
       setter(def, textTemplatePath, '{{data | number:\'d\'}}');
     }
   } else if (encoding.isTypes(name, [N, O]) && encoding.axis(name).maxLabelLength) {

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -39,7 +39,7 @@ function box(encoding, stats) {
   if (hasX) {
     if (encoding.isOrdinalScale(X)) {
       // for ordinal, hasCol or not doesn't matter -- we scale based on cardinality
-      cellWidth = (xCardinality + encoding.band(X).padding) * encoding.bandSize(X, useSmallBand);
+      cellWidth = (xCardinality + encoding.field(X).band.padding) * encoding.bandSize(X, useSmallBand);
     } else {
       cellWidth = hasCol || hasRow ? encoding.field(COL).width :  encoding.config('singleWidth');
     }
@@ -55,7 +55,7 @@ function box(encoding, stats) {
   if (hasY) {
     if (encoding.isOrdinalScale(Y)) {
       // for ordinal, hasCol or not doesn't matter -- we scale based on cardinality
-      cellHeight = (yCardinality + encoding.band(Y).padding) * encoding.bandSize(Y, useSmallBand);
+      cellHeight = (yCardinality + encoding.field(Y).band.padding) * encoding.bandSize(Y, useSmallBand);
     } else {
       cellHeight = hasCol || hasRow ? encoding.field(ROW).height :  encoding.config('singleHeight');
     }

--- a/src/compiler/legend.js
+++ b/src/compiler/legend.js
@@ -40,12 +40,15 @@ legend.defs = function(encoding) {
 };
 
 legend.def = function(name, encoding, props) {
-  var def = props, timeUnit;
+  var def = props,
+    timeUnit = encoding.field(name).timeUnit;
 
   def.title = encoding.fieldTitle(name);
 
-  if (encoding.isType(name, T) && (timeUnit = encoding.timeUnit(name)) &&
-    time.hasScale(timeUnit)) {
+  if (encoding.isType(name, T) &&
+    timeUnit &&
+    time.hasScale(timeUnit)
+  ) {
     var properties = def.properties = def.properties || {},
       labels = properties.labels = properties.labels || {},
       text = labels.text = labels.text || {};

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -163,7 +163,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
     case Y:
       if (s.type === 'ordinal') { //&& !s.bandWidth
         s.points = true;
-        s.padding = encoding.band(s.name).padding;
+        s.padding = encoding.field(s.name).band.padding;
       }
   }
 }

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -39,7 +39,7 @@ scale.type = function(name, encoding) {
     case N: //fall through
     case O: return 'ordinal';
     case T:
-      var timeUnit = encoding.timeUnit(name);
+      var timeUnit = encoding.field(name).timeUnit;
       return timeUnit ? time.scale.type(timeUnit, name) : 'time';
     case Q:
       if (encoding.bin(name)) {
@@ -51,7 +51,7 @@ scale.type = function(name, encoding) {
 
 scale.domain = function (name, encoding, sorting, opt) {
   if (encoding.isType(name, T)) {
-    var range = time.scale.domain(encoding.timeUnit(name), name);
+    var range = time.scale.domain(encoding.field(name).timeUnit, name);
     if(range) return range;
   }
 
@@ -70,7 +70,9 @@ scale.domain = function (name, encoding, sorting, opt) {
 
 function scale_range(s, encoding, layout, stats, style, opt) {
   // jshint unused:false
-  var spec = encoding.scale(s.name);
+  var spec = encoding.scale(s.name),
+    timeUnit = encoding.field(s.name).timeUnit;
+
   switch (s.name) {
     case X:
       if (s.type === 'ordinal') {
@@ -78,7 +80,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       } else {
         s.range = layout.cellWidth ? [0, layout.cellWidth] : 'width';
 
-        if (encoding.isType(s.name,T) && encoding.timeUnit(s.name) === 'year') {
+        if (encoding.isType(s.name,T) && timeUnit === 'year') {
           s.zero = false;
         } else {
           s.zero = spec.zero === undefined ? true : spec.zero;
@@ -88,7 +90,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       }
       s.round = true;
       if (s.type === 'time') {
-        s.nice = encoding.timeUnit(s.name);
+        s.nice = timeUnit;
       }else {
         s.nice = true;
       }
@@ -99,7 +101,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       } else {
         s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
 
-        if (encoding.isType(s.name,T) && encoding.timeUnit(s.name) === 'year') {
+        if (encoding.isType(s.name,T) && timeUnit === 'year') {
           s.zero = false;
         } else {
           s.zero = spec.zero === undefined ? true : spec.zero;
@@ -111,7 +113,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       s.round = true;
 
       if (s.type === 'time') {
-        s.nice = encoding.timeUnit(s.name) || encoding.config('timeScaleNice');
+        s.nice = timeUnit || encoding.config('timeScaleNice');
       }else {
         s.nice = true;
       }


### PR DESCRIPTION
@domoritz   

I kinda feel annoy to have helpers in `encoding` for every single property of a field.   
That said, we still need some of them.  So I'm not sure if we should do this.  
That said, I created this branch on the plane, so would love to know what you think.  