### PR TITLE
Sorted bin scale

### DIFF
--- a/gallery/gallery.js
+++ b/gallery/gallery.js
@@ -67,6 +67,22 @@ var EXAMPLES = [
         color: {type: 'O',name: 'year'}
       }
     }
+  },{
+    title: 'Binned plots',
+    spec: {
+      'marktype': 'point',
+      'encoding': {
+        'x': {'bin': true,'name': 'Displacement','type': 'Q'},
+        'y': {'bin': true,'name': 'Miles_per_Gallon','type': 'Q'},
+        'size': {
+          'name': '*',
+          'aggregate': 'count',
+          'type': 'Q',
+          'displayName': 'Number of Records'
+        }
+      },
+      'data': {'url': 'data/cars.json'}
+    }
   }
 ];
 

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -23,11 +23,11 @@ scale.defs = function(names, encoding, layout, stats, style, sorting, opt) {
       type: scale.type(name, encoding),
       domain: scale.domain(name, encoding, sorting, opt)
     };
-    if (s.type === 'ordinal' && !encoding.bin(name) && encoding.sort(name).length === 0) {
-      s.sort = true;
-    }
 
-    scale_range(s, encoding, layout, stats, style, opt);
+    s.sort = s.type === 'ordinal' && (
+        encoding.bin(name) ||
+        encoding.sort(name).length === 0
+      );
 
     return (a.push(s), a);
   }, []);
@@ -90,11 +90,10 @@ function scale_range(s, encoding, layout, stats, style, opt) {
 
   switch (s.name) {
     case X:
+      s.range = layout.cellWidth ? [0, layout.cellWidth] : 'width';
       if (s.type === 'ordinal') {
         s.bandWidth = encoding.bandSize(X, layout.x.useSmallBand);
       } else {
-        s.range = layout.cellWidth ? [0, layout.cellWidth] : 'width';
-
         if (encoding.isType(s.name,T) && timeUnit === 'year') {
           s.zero = false;
         } else {
@@ -111,11 +110,10 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       }
       break;
     case Y:
+      s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
       if (s.type === 'ordinal') {
         s.bandWidth = encoding.bandSize(Y, layout.y.useSmallBand);
       } else {
-        s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
-
         if (encoding.isType(s.name,T) && timeUnit === 'year') {
           s.zero = false;
         } else {

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -24,13 +24,19 @@ scale.defs = function(names, encoding, layout, stats, style, sorting, opt) {
       domain: scale.domain(name, encoding, sorting, opt)
     };
 
-    s.sort = s.type === 'ordinal' && (
-        encoding.bin(name) ||
-        encoding.sort(name).length === 0
-      );
+    s.sort = scale.sort(s, encoding, name) || undefined;
+
+    scale.range(s, encoding, layout, stats, style, opt);
 
     return (a.push(s), a);
   }, []);
+};
+
+scale.sort = function(s, encoding, name) {
+  return s.type === 'ordinal' && (
+    !!encoding.bin(name) ||
+    encoding.sort(name).length === 0
+  );
 };
 
 scale.type = function(name, encoding) {
@@ -83,7 +89,7 @@ scale.domain = function (name, encoding, sorting, opt) {
 };
 
 
-function scale_range(s, encoding, layout, stats, style, opt) {
+scale.range = function (s, encoding, layout, stats, style, opt) {
   // jshint unused:false
   var spec = encoding.scale(s.name),
     timeUnit = encoding.field(s.name).timeUnit;
@@ -181,7 +187,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
         s.padding = encoding.field(s.name).band.padding;
       }
   }
-}
+};
 
 scale.color = function(s, encoding, stats) {
   var colorScale = encoding.scale(COLOR),

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -39,7 +39,7 @@ describe('vl.compile.scale', function() {
             name: 'origin'
           }
         }
-      }), {}, {
+      }), {}, {}, {
         stack: 'y',
         facet: true
       });
@@ -58,7 +58,7 @@ describe('vl.compile.scale', function() {
             name: 'origin'
           }
         }
-      }), {}, {
+      }), {}, {}, {
         stack: 'y',
         facet: true
       });
@@ -74,15 +74,15 @@ describe('vl.compile.scale', function() {
         var domain = vlscale.domain('y', Encoding.fromSpec({
           encoding: {
             y: {
-              bin: true,
+              bin: {maxbins: 15},
               name: 'origin',
               scale: {useRawDomain: true},
               type: Q
             }
           }
-        }), sorting, {});
+        }), {origin: {min: -5, max:48}}, sorting, {});
 
-        expect(domain.data).to.eql(sortingReturn);
+        expect(domain).to.eql([-5, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45]);
       });
 
     it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
@@ -96,7 +96,7 @@ describe('vl.compile.scale', function() {
               type: Q
             }
           }
-        }), {}, {});
+        }), {}, {}, {});
 
         expect(domain.data).to.eql(RAW);
       });
@@ -112,7 +112,7 @@ describe('vl.compile.scale', function() {
               type: Q
             }
           }
-        }), sorting, {});
+        }), {}, sorting, {});
 
         expect(domain.data).to.eql(sortingReturn);
       });
@@ -127,7 +127,7 @@ describe('vl.compile.scale', function() {
               type: T
             }
           }
-        }), {}, {});
+        }), {}, {}, {});
 
         expect(domain.data).to.eql(RAW);
       });
@@ -143,7 +143,7 @@ describe('vl.compile.scale', function() {
               timeUnit: 'year'
             }
           }
-        }), {}, {});
+        }), {}, {}, {});
 
         expect(domain.data).to.eql(RAW);
       });
@@ -159,7 +159,7 @@ describe('vl.compile.scale', function() {
               timeUnit: 'month'
             }
           }
-        }), sorting, {});
+        }), {}, sorting, {});
 
         expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
       });
@@ -174,7 +174,7 @@ describe('vl.compile.scale', function() {
             type: Q
           }
         }
-      }), sorting, {});
+      }),  {}, sorting, {});
 
       expect(domain.data).to.eql(sortingReturn);
     });

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -8,89 +8,169 @@ var util = require('../../src/util'),
   vlscale = require('../../src/compiler/scale'),
   colorbrewer = require('colorbrewer');
 
-describe('vl.compile.scale.domain()', function() {
-  var sortingReturn = 'sorted',
-    sorting = {
-      getDataset: function() {return 'sorted';}
-    };
+describe('vl.compile.scale', function() {
+  describe('sort()', function() {
+    it('should return true for any ordinal or binned field', function() {
+      var encoding = Encoding.fromSpec({
+          encoding: {
+            x: { name: 'origin', type: O},
+            y: { bin: true, name: 'origin', type: Q}
+          }
+        });
 
-  it('should return correct stack', function() {
-    var domain = vlscale.domain('y', Encoding.fromSpec({
-      encoding: {
-        y: {
-          name: 'origin'
-        }
-      }
-    }), {}, {
-      stack: 'y',
-      facet: true
+      expect(vlscale.sort({type: 'ordinal'}, encoding, 'x'))
+        .to.eql(true);
+      expect(vlscale.sort({type: 'ordinal'}, encoding, 'y'))
+        .to.eql(true);
     });
 
-    expect(domain).to.eql({
-      data: 'stacked',
-      field: 'data.max_sum_origin'
-    });
   });
 
-  it('should return correct aggregated stack', function() {
-    var domain = vlscale.domain('y', Encoding.fromSpec({
-      encoding: {
-        y: {
-          aggregate: 'sum',
-          name: 'origin'
-        }
-      }
-    }), {}, {
-      stack: 'y',
-      facet: true
-    });
+  describe('domain()', function() {
+    var sortingReturn = 'sorted',
+      sorting = {
+        getDataset: function() {return 'sorted';}
+      };
 
-    expect(domain).to.eql({
-      data: 'stacked',
-      field: 'data.max_sum_sum_origin'
-    });
-  });
-
-  it('should return the right domain if binned Q',
-    function() {
+    it('should return correct stack', function() {
       var domain = vlscale.domain('y', Encoding.fromSpec({
         encoding: {
           y: {
-            bin: true,
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: Q
+            name: 'origin'
           }
         }
-      }), sorting, {});
+      }), {}, {
+        stack: 'y',
+        facet: true
+      });
 
-      expect(domain.data).to.eql(sortingReturn);
+      expect(domain).to.eql({
+        data: 'stacked',
+        field: 'data.max_sum_origin'
+      });
     });
 
-  it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            aggregate: 'mean',
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: Q
-          }
-        }
-      }), {}, {});
-
-      expect(domain.data).to.eql(RAW);
-    });
-
-  it('should return the aggregate domain for sum Q',
-    function() {
+    it('should return correct aggregated stack', function() {
       var domain = vlscale.domain('y', Encoding.fromSpec({
         encoding: {
           y: {
             aggregate: 'sum',
+            name: 'origin'
+          }
+        }
+      }), {}, {
+        stack: 'y',
+        facet: true
+      });
+
+      expect(domain).to.eql({
+        data: 'stacked',
+        field: 'data.max_sum_sum_origin'
+      });
+    });
+
+    it('should return the right domain if binned Q',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              bin: true,
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: Q
+            }
+          }
+        }), sorting, {});
+
+        expect(domain.data).to.eql(sortingReturn);
+      });
+
+    it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              aggregate: 'mean',
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: Q
+            }
+          }
+        }), {}, {});
+
+        expect(domain.data).to.eql(RAW);
+      });
+
+    it('should return the aggregate domain for sum Q',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              aggregate: 'sum',
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: Q
+            }
+          }
+        }), sorting, {});
+
+        expect(domain.data).to.eql(sortingReturn);
+      });
+
+    it('should return the raw domain if useRawDomain is true for raw T',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: T
+            }
+          }
+        }), {}, {});
+
+        expect(domain.data).to.eql(RAW);
+      });
+
+    it('should return the raw domain if useRawDomain is true for year T',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: T,
+              timeUnit: 'year'
+            }
+          }
+        }), {}, {});
+
+        expect(domain.data).to.eql(RAW);
+      });
+
+    it('should return the correct domain for month T',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: T,
+              timeUnit: 'month'
+            }
+          }
+        }), sorting, {});
+
+        expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+      });
+
+    it('should return the aggregated domain if useRawDomain is false', function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            aggregate: 'min',
             name: 'origin',
-            scale: {useRawDomain: true},
+            scale: {useRawDomain: false},
             type: Q
           }
         }
@@ -99,127 +179,66 @@ describe('vl.compile.scale.domain()', function() {
       expect(domain.data).to.eql(sortingReturn);
     });
 
-  it('should return the raw domain if useRawDomain is true for raw T',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: T
-          }
-        }
-      }), {}, {});
-
-      expect(domain.data).to.eql(RAW);
-    });
-
-  it('should return the raw domain if useRawDomain is true for year T',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: T,
-            timeUnit: 'year'
-          }
-        }
-      }), {}, {});
-
-      expect(domain.data).to.eql(RAW);
-    });
-
-  it('should return the correct domain for month T',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: T,
-            timeUnit: 'month'
-          }
-        }
-      }), sorting, {});
-
-      expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-    });
-
-  it('should return the aggregated domain if useRawDomain is false', function() {
-    var domain = vlscale.domain('y', Encoding.fromSpec({
-      encoding: {
-        y: {
-          aggregate: 'min',
-          name: 'origin',
-          scale: {useRawDomain: false},
-          type: Q
-        }
-      }
-    }), sorting, {});
-
-    expect(domain.data).to.eql(sortingReturn);
+    // TODO test other cases
   });
 
-  // TODO test other cases
-});
+  describe('color.palette', function() {
+    it('should return tableau categories', function() {
+      expect(vlscale.color.palette('category10k')).to.eql(
+        ['#2ca02c', '#e377c2', '#7f7f7f', '#17becf', '#8c564b', '#d62728', '#bcbd22',
+          '#9467bd', '#ff7f0e', '#1f77b4'
+        ]
+      );
+    });
 
-describe('vl.compile.scale.color.palette', function() {
-  it('should return tableau categories', function() {
-    expect(vlscale.color.palette('category10k')).to.eql(
-      ['#2ca02c', '#e377c2', '#7f7f7f', '#17becf', '#8c564b', '#d62728', '#bcbd22',
-        '#9467bd', '#ff7f0e', '#1f77b4'
-      ]
-    );
-  });
+    it('should return pre-defined brewer palette if low cardinality', function() {
+      var brewerPalettes = util.keys(colorbrewer);
+      brewerPalettes.forEach(function(palette) {
+        util.range(3, 9).forEach(function(cardinality) {
+          expect(vlscale.color.palette(palette, cardinality)).to.eql(
+            colorbrewer[palette][cardinality]
+          );
+        });
+      });
+    });
 
-  it('should return pre-defined brewer palette if low cardinality', function() {
-    var brewerPalettes = util.keys(colorbrewer);
-    brewerPalettes.forEach(function(palette) {
-      util.range(3, 9).forEach(function(cardinality) {
-        expect(vlscale.color.palette(palette, cardinality)).to.eql(
-          colorbrewer[palette][cardinality]
+    it('should return pre-defined brewer palette if high cardinality N', function() {
+      var brewerPalettes = util.keys(colorbrewer);
+      brewerPalettes.forEach(function(palette) {
+        var cardinality = 20;
+        expect(vlscale.color.palette(palette, cardinality, 'N')).to.eql(
+          colorbrewer[palette][Math.max.apply(null, util.keys(colorbrewer[palette]))]
+        );
+      });
+    });
+
+    it('should return interpolated scale if high cardinality ordinal', function() {
+      var brewerPalettes = util.keys(colorbrewer);
+      brewerPalettes.forEach(function(palette) {
+        var cardinality = 20,
+          ps = 5,
+          p = colorbrewer[palette],
+          interpolator = d3.interpolateLab(p[ps][0], p[ps][ps - 1]);
+        expect(vlscale.color.palette(palette, cardinality, 'O')).to.eql(
+          util.range(cardinality).map(function(i) {
+            return interpolator(i * 1.0 / (cardinality - 1));
+          })
         );
       });
     });
   });
 
-  it('should return pre-defined brewer palette if high cardinality N', function() {
-    var brewerPalettes = util.keys(colorbrewer);
-    brewerPalettes.forEach(function(palette) {
-      var cardinality = 20;
-      expect(vlscale.color.palette(palette, cardinality, 'N')).to.eql(
-        colorbrewer[palette][Math.max.apply(null, util.keys(colorbrewer[palette]))]
-      );
+  describe('color.interpolate', function() {
+    it('should interpolate color along the lab space', function() {
+      var interpolator = d3.interpolateLab('#ffffff', '#000000'),
+        cardinality = 8;
+
+      expect(vlscale.color.interpolate('#ffffff', '#000000', cardinality))
+        .to.eql(
+          util.range(cardinality).map(function(i) {
+            return interpolator(i * 1.0 / (cardinality - 1));
+          })
+        );
     });
-  });
-
-  it('should return interpolated scale if high cardinality ordinal', function() {
-    var brewerPalettes = util.keys(colorbrewer);
-    brewerPalettes.forEach(function(palette) {
-      var cardinality = 20,
-        ps = 5,
-        p = colorbrewer[palette],
-        interpolator = d3.interpolateLab(p[ps][0], p[ps][ps - 1]);
-      expect(vlscale.color.palette(palette, cardinality, 'O')).to.eql(
-        util.range(cardinality).map(function(i) {
-          return interpolator(i * 1.0 / (cardinality - 1));
-        })
-      );
-    });
-  });
-});
-
-describe('vl.compile.scale.color.interpolate', function() {
-  it('should interpolate color along the lab space', function() {
-    var interpolator = d3.interpolateLab('#ffffff', '#000000'),
-      cardinality = 8;
-
-    expect(vlscale.color.interpolate('#ffffff', '#000000', cardinality))
-      .to.eql(
-        util.range(cardinality).map(function(i) {
-          return interpolator(i * 1.0 / (cardinality - 1));
-        })
-      );
   });
 });

--- a/test/compiler/stack.spec.js
+++ b/test/compiler/stack.spec.js
@@ -3,18 +3,7 @@
 var expect = require('chai').expect;
 var fixtures = require('../fixtures').stack;
 
-var compile = require('../../src/vl').compile,
-  util = require('../../src/util');
-
-// mock util.getbins()
-util.getbins = function() {
-  return {
-    start: 0,
-    stop: 10,
-    step: 1
-  };
-};
-
+var compile = require('../../src/vl').compile;
 
 var stats = {
   'Cost__Total_$': {

--- a/test/field.spec.js
+++ b/test/field.spec.js
@@ -20,7 +20,7 @@ describe('vl.field.cardinality()', function () {
       var field = {name:2, type:'Q', bin: {maxbins: 15}};
       var stats = {2:{distinct: 10, min:0, max:150}};
       var cardinality = vlfield.cardinality(field, stats);
-      expect(cardinality).to.equal(10);
+      expect(cardinality).to.equal(15);
     });
   });
 });


### PR DESCRIPTION
- fixes #454 by setting `sort:true` for binned axis and always set `range:'width/height'` for ordinal scale
- Fixes #505 -- feed bin scale's domain with all the bin value