### PR TITLE
Axis label offset

### DIFF
--- a/editor/editor.js
+++ b/editor/editor.js
@@ -155,10 +155,7 @@ vled.datasetChanged = function(dataset, callback) {
 
   d3.json(dataset.url, function(err, data) {
     if (err) return alert('Error loading data ' + err.statusText);
-    dataset.stats = vl.summary(data).reduce(function(s, p) {
-      s[p.field] = p;
-      return s;
-    },{});
+    dataset.stats = vl.data.stats(data);
     callback();
   });
 };

--- a/gallery/gallery.js
+++ b/gallery/gallery.js
@@ -67,6 +67,22 @@ var EXAMPLES = [
         color: {type: 'O',name: 'year'}
       }
     }
+  },{
+    title: 'Binned plots',
+    spec: {
+      'marktype': 'point',
+      'encoding': {
+        'x': {'bin': true,'name': 'Displacement','type': 'Q'},
+        'y': {'bin': true,'name': 'Miles_per_Gallon','type': 'Q'},
+        'size': {
+          'name': '*',
+          'aggregate': 'count',
+          'type': 'Q',
+          'displayName': 'Number of Records'
+        }
+      },
+      'data': {'url': 'data/cars.json'}
+    }
   }
 ];
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "colorbrewer": "0.0.2",
     "d3-color": "^0.2.1",
+    "d3-time-format": "0.0.2",
     "datalib": "^1.3.0"
   },
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chai": "^3.0.0",
     "commander": "^2.8.1",
     "coveralls": "^2.11.2",
-    "d3": "^3.5.5",
+    "d3": "^3.5.6",
     "deep-diff": "^0.3.2",
     "gulp": "^3.9.0",
     "gulp-bump": "^0.3.1",
@@ -57,6 +57,7 @@
   "dependencies": {
     "colorbrewer": "0.0.2",
     "d3-color": "^0.2.1",
+    "d3-format": "^0.2.3",
     "d3-time-format": "0.0.2",
     "datalib": "^1.3.0"
   },

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -190,12 +190,10 @@ module.exports = (function() {
     return this._enc[et].value;
   };
 
-  proto.numberFormat = function(et, fieldStats) {
-    return this._enc[et].axis.numberFormat ||
-      this.config(
-        fieldStats && fieldStats.max > this.config('maxSmallNumber') ?
-        'largeNumberFormat' : 'smallNumberFormat'
-      );
+  proto.numberFormat = function(fieldStats) {
+    var formatConfig = fieldStats.max > this.config('maxSmallNumber') ?
+      'largeNumberFormat': 'smallNumberFormat';
+    return this.config(formatConfig);
   };
 
   proto.sort = function(et, stats) {

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -27,8 +27,7 @@ axis.defs = function(names, encoding, layout, stats, opt) {
 axis.def = function(name, encoding, layout, stats, opt) {
   var isCol = name == COL,
     isRow = name == ROW,
-    type = isCol ? 'x' : isRow ? 'y' : name,
-    rowOffset = axis.titleOffset(encoding, layout, Y) + 20;
+    type = isCol ? 'x' : isRow ? 'y' : name;
 
   var def = {
     type: type,
@@ -36,21 +35,18 @@ axis.def = function(name, encoding, layout, stats, opt) {
     properties: {}
   };
 
-  def = axis.grid(def, name, encoding, layout, rowOffset);
+
+  if(isRow) def.offset = axis.titleOffset(encoding, layout, Y) + 20;
+
+  def = axis.grid(def, name, encoding, layout);
   def = axis.title(def, name, encoding, layout, opt);
 
   def.titleOffset = axis.titleOffset(encoding, layout, name);
 
-  if (isRow || isCol) {
-    def = axis.hideTicks(def);
-  }
+  if (isRow || isCol) def = axis.hideTicks(def);
 
   if (isCol) {
     def.orient = 'top';
-  }
-
-  if (isRow) {
-    def.offset = rowOffset;
   }
 
   if (name == X) {
@@ -81,7 +77,7 @@ axis.def = function(name, encoding, layout, stats, opt) {
   return def;
 };
 
-axis.grid = function(def, name, encoding, layout, rowOffset) {
+axis.grid = function(def, name, encoding, layout) {
   var cellPadding = layout.cellPadding,
     isCol = name == COL,
     isRow = name == ROW;
@@ -113,10 +109,10 @@ axis.grid = function(def, name, encoding, layout, rowOffset) {
           scale: 'row'
         },
         x: {
-          value: rowOffset
+          value: def.offset
         },
         x2: {
-          offset: rowOffset + (layout.cellWidth * 0.05),
+          offset: def.offset + (layout.cellWidth * 0.05),
           // default value(s) -- vega doesn't do recursive merge
           group: 'mark.group.width',
           mult: 1

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -25,14 +25,10 @@ axis.defs = function(names, encoding, layout, stats, opt) {
 };
 
 axis.def = function(name, encoding, layout, stats, opt) {
-  var type = name;
-  var isCol = name == COL, isRow = name == ROW;
-  var rowOffset = axisTitleOffset(encoding, layout, Y) + 20,
-    cellPadding = layout.cellPadding;
-
-
-  if (isCol) type = 'x';
-  if (isRow) type = 'y';
+  var isCol = name == COL,
+    isRow = name == ROW,
+    type = isCol ? 'x' : isRow ? 'y' : name,
+    rowOffset = axis.titleOffset(encoding, layout, Y) + 20;
 
   var def = {
     type: type,

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -160,29 +160,26 @@ function axis_title(def, name, encoding, layout, opt) {
 axis.labels = function (def, name, encoding, layout, stats, opt) {
   // jshint unused:false
 
-  var timeUnit = encoding.field(name).timeUnit;
+  var timeUnit = encoding.field(name).timeUnit,
+    fieldStats = stats[encoding.field(name).name];
 
   // add custom label for time type
   if (encoding.isType(name, T) && timeUnit && (time.hasScale(timeUnit))) {
     setter(def, ['properties','labels','text','scale'], 'time-'+ timeUnit);
   }
 
-  var textTemplatePath = ['properties','labels','text','template'];
   if (encoding.axis(name).format) {
     def.format = encoding.axis(name).format;
-  } else if (encoding.isType(name, Q)) {
-    var fieldStats = stats[encoding.fieldName(name)],
-      numberFormat = encoding.numberFormat(name, fieldStats);
-
-    setter(def, textTemplatePath, '{{data | number:\'' + numberFormat + '\'}}');
+  } else if (encoding.isType(name, Q) || fieldStats.type === 'number') {
+    def.format = encoding.numberFormat(fieldStats);
   } else if (encoding.isType(name, T)) {
     if (!timeUnit) {
-      setter(def, textTemplatePath, '{{data | time:\'' +
-             encoding.config('timeFormat') + '\'}}');
+      def.format = encoding.config('timeFormat');
     } else if (timeUnit === 'year') {
-      setter(def, textTemplatePath, '{{data | number:\'d\'}}');
+      def.format = '';
     }
   } else if (encoding.isTypes(name, [N, O]) && encoding.axis(name).maxLabelLength) {
+    var textTemplatePath = ['properties','labels','text','template'];
     setter(def, textTemplatePath, '{{data | truncate:' + encoding.axis(name).maxLabelLength + '}}');
   } else {
     // nothing

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -176,7 +176,7 @@ axis.labels = function (def, name, encoding, layout, stats, opt) {
     if (!timeUnit) {
       def.format = encoding.config('timeFormat');
     } else if (timeUnit === 'year') {
-      def.format = '';
+      def.format = 'd';
     }
   } else if (encoding.isTypes(name, [N, O]) && encoding.axis(name).maxLabelLength) {
     var textTemplatePath = ['properties','labels','text','template'];

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -32,7 +32,8 @@ axis.def = function(name, encoding, layout, stats, opt) {
 
   var def = {
     type: type,
-    scale: name
+    scale: name,
+    properties: {}
   };
 
   if (encoding.axis(name).grid) {
@@ -41,7 +42,7 @@ axis.def = function(name, encoding, layout, stats, opt) {
 
     if (isCol) {
       // set grid property -- put the lines on the right the cell
-      setter(def, ['properties', 'grid'], {
+      def.properties.grid = {
         x: {
           offset: layout.cellWidth * (1+ cellPadding/2.0),
           // default value(s) -- vega doesn't do recursive merge
@@ -52,10 +53,10 @@ axis.def = function(name, encoding, layout, stats, opt) {
         },
         stroke: { value: encoding.config('cellGridColor') },
         opacity: { value: encoding.config('cellGridOpacity') }
-      });
+      };
     } else if (isRow) {
       // set grid property -- put the lines on the top
-      setter(def, ['properties', 'grid'], {
+      def.properties.grid = {
         y: {
           offset: -layout.cellHeight * (cellPadding/2),
           // default value(s) -- vega doesn't do recursive merge
@@ -72,12 +73,12 @@ axis.def = function(name, encoding, layout, stats, opt) {
         },
         stroke: { value: encoding.config('cellGridColor') },
         opacity: { value: encoding.config('cellGridOpacity') }
-      });
+      };
     } else {
-      setter(def, ['properties', 'grid'], {
+      def.properties.grid = {
         stroke: { value: encoding.config('gridColor') },
         opacity: { value: encoding.config('gridOpacity') }
-      });
+      };
     }
   }
 

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -50,8 +50,8 @@ compiler.compileEncoding = function (encoding, stats) {
     dataTable = spec.data[1];
 
   rawTable = filter.addFilters(rawTable, encoding); // modify rawTable
+  spec = compiler.time(spec, encoding);              // modify rawTable, add scales
   dataTable = compiler.bin(dataTable, encoding);     // modify dataTable
-  spec = compiler.time(spec, encoding);              // modify dataTable, add scales
   var aggResult = compiler.aggregate(dataTable, encoding); // modify dataTable
   var sorting = compiler.sort(spec.data, encoding, stats); // append new data
 

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -3,7 +3,8 @@
 require('../globals');
 
 var util = require('../util'),
-  setter = util.setter;
+  setter = util.setter,
+  time = require('./time');
 
 module.exports = vllayout;
 
@@ -96,7 +97,8 @@ function getMaxLength(encoding, stats, et) {
   } else if (encoding.isType(et, Q)) {
     return 10;
   } else if (encoding.isType(et, T)) {
-    return 15;
+    return time.maxLength(encoding.field(et).timeUnit,
+                          encoding.config('timeFormat'));
   } else if (encoding.isTypes(et, [N, O]) && encoding.axis(et).maxLabelLength) {
     return Math.min(stats[encoding.fieldName(et)].max, encoding.axis(et).maxLabelLength);
   }

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -4,7 +4,8 @@ require('../globals');
 
 var util = require('../util'),
   setter = util.setter,
-  time = require('./time');
+  time = require('./time'),
+  d3_format = require('d3-format');
 
 module.exports = vllayout;
 
@@ -90,39 +91,62 @@ function box(encoding, stats) {
   };
 }
 
+
+// FIXME fieldStats.max isn't always the longest
+function getMaxNumberLength(encoding, et, fieldStats) {
+  var format = encoding.numberFormat(et, fieldStats);
+
+  return d3_format.format(format)(fieldStats.max).length;
+}
+
 function getMaxLength(encoding, stats, et) {
-  // FIXME determine constant for Q and T in a nicer way
-  if (encoding.bin(et)) {
-    return 5;
-  } else if (encoding.isType(et, Q)) {
-    return 10;
+  var field = encoding.field(et),
+    fieldStats = stats[field.name];
+
+  if (field.bin) {
+    // TODO once bin support range, need to update this
+    return getMaxNumberLength(encoding, et, fieldStats);
+  } if (encoding.isType(et, Q)) {
+    return getMaxNumberLength(encoding, et, fieldStats);
   } else if (encoding.isType(et, T)) {
     return time.maxLength(encoding.field(et).timeUnit, encoding);
-  } else if (encoding.isTypes(et, [N, O]) && encoding.axis(et).maxLabelLength) {
-    return Math.min(stats[encoding.fieldName(et)].max, encoding.axis(et).maxLabelLength);
+  } else if (encoding.isTypes(et, [N, O])) {
+    if(fieldStats.type === 'number') {
+      return getMaxNumberLength(encoding, et, fieldStats);
+    } else {
+      return Math.min(fieldStats.max, encoding.axis(et).maxLabelLength || Infinity);
+    }
   }
-  return stats[encoding.fieldName(et)].max;
 }
 
 function offset(encoding, stats, layout) {
   [X, Y].forEach(function (et) {
     var maxLength;
     if (encoding.isDimension(et) || encoding.isType(et, T)) {
-      maxLength =  getMaxLength(encoding, stats, et);
-    } else if (encoding.aggregate(et) === 'count') {
-      //assign default value for count as it won't have stats
-      maxLength =  3; //FIXME
-    } else if (encoding.isType(et, Q)) {
-      if (et===X) {
-        maxLength = 3;
-      } else { // Y
-        //assume that default formating is always shorter than 7
-        maxLength = Math.min(getMaxLength(encoding, stats, et), 7);
+      maxLength = getMaxLength(encoding, stats, et);
+    } else if (
+      // TODO once we have #512 (allow using inferred type)
+      // Need to adjust condition here.
+      encoding.isType(et, Q) ||
+      encoding.aggregate(et) === 'count'
+    ) {
+      if (
+        et===Y ||
+        // FIXME some times might not rotate, but need to move this to axis.js first
+        (et===X && false)
+      ) {
+        maxLength = getMaxLength(encoding, stats, et);
       }
     } else {
       // nothing
     }
-    setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') *  maxLength + 20);
+
+    if (maxLength) {
+      setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') *  maxLength + 20);
+    } else {
+      setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') * 3 + 20);
+    }
+
   });
   return layout;
 }

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -97,8 +97,7 @@ function getMaxLength(encoding, stats, et) {
   } else if (encoding.isType(et, Q)) {
     return 10;
   } else if (encoding.isType(et, T)) {
-    return time.maxLength(encoding.field(et).timeUnit,
-                          encoding.config('timeFormat'));
+    return time.maxLength(encoding.field(et).timeUnit, encoding);
   } else if (encoding.isTypes(et, [N, O]) && encoding.axis(et).maxLabelLength) {
     return Math.min(stats[encoding.fieldName(et)].max, encoding.axis(et).maxLabelLength);
   }

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -104,24 +104,24 @@ function getMaxLength(encoding, stats, et) {
 }
 
 function offset(encoding, stats, layout) {
-  [X, Y].forEach(function (x) {
+  [X, Y].forEach(function (et) {
     var maxLength;
-    if (encoding.isDimension(x) || encoding.isType(x, T)) {
-      maxLength =  getMaxLength(encoding, stats, x);
-    } else if (encoding.aggregate(x) === 'count') {
+    if (encoding.isDimension(et) || encoding.isType(et, T)) {
+      maxLength =  getMaxLength(encoding, stats, et);
+    } else if (encoding.aggregate(et) === 'count') {
       //assign default value for count as it won't have stats
-      maxLength =  3;
-    } else if (encoding.isType(x, Q)) {
-      if (x===X) {
+      maxLength =  3; //FIXME
+    } else if (encoding.isType(et, Q)) {
+      if (et===X) {
         maxLength = 3;
       } else { // Y
         //assume that default formating is always shorter than 7
-        maxLength = Math.min(getMaxLength(encoding, stats, x), 7);
+        maxLength = Math.min(getMaxLength(encoding, stats, et), 7);
       }
     } else {
       // nothing
     }
-    setter(layout,[x, 'axisTitleOffset'], encoding.config('characterWidth') *  maxLength + 20);
+    setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') *  maxLength + 20);
   });
   return layout;
 }

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -121,7 +121,9 @@ function getMaxLength(encoding, stats, et) {
 
 function offset(encoding, stats, layout) {
   [X, Y].forEach(function (et) {
-    var maxLength;
+    // TODO(kanitw): Jul 19, 2015 - create a set of visual test for extraOffset
+    var extraOffset = et === X ? 20 : 22,
+      maxLength;
     if (encoding.isDimension(et) || encoding.isType(et, T)) {
       maxLength = getMaxLength(encoding, stats, et);
     } else if (
@@ -131,9 +133,9 @@ function offset(encoding, stats, layout) {
       encoding.aggregate(et) === 'count'
     ) {
       if (
-        et===Y ||
-        // FIXME some times might not rotate, but need to move this to axis.js first
-        (et===X && false)
+        et===Y
+        // || (et===X && false)
+        // FIXME determine when X would rotate, but should move this to axis.js first
       ) {
         maxLength = getMaxLength(encoding, stats, et);
       }
@@ -142,9 +144,10 @@ function offset(encoding, stats, layout) {
     }
 
     if (maxLength) {
-      setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') *  maxLength + 20);
+      setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') *  maxLength + extraOffset);
     } else {
-      setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') * 3 + 20);
+      // if no max length (no rotation case), use maxLength = 3
+      setter(layout,[et, 'axisTitleOffset'], encoding.config('characterWidth') * 3 + extraOffset);
     }
 
   });

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -411,7 +411,7 @@ function filled_point_props(shape) {
 
 function text_props(e, layout, style, stats) {
   var p = {},
-    textField = e.field(TEXT);
+    field = e.field(TEXT);
 
   // x
   if (e.has(X)) {
@@ -435,12 +435,12 @@ function text_props(e, layout, style, stats) {
   if (e.has(SIZE)) {
     p.fontSize = {scale: SIZE, field: e.fieldRef(SIZE)};
   } else if (!e.has(SIZE)) {
-    p.fontSize = {value: textField.font.size};
+    p.fontSize = {value: field.font.size};
   }
 
   // fill
   // color should be set to background
-  p.fill = {value: textField.text.color};
+  p.fill = {value: field.text.color};
 
   // alpha
   if (e.has(ALPHA)) {
@@ -455,22 +455,22 @@ function text_props(e, layout, style, stats) {
   if (e.has(TEXT)) {
     if (e.isType(TEXT, Q)) {
       var fieldStats = stats[e.fieldName(name)],
-        numberFormat = textField.format || e.numberFormat(fieldStats);
+        numberFormat = field.format || e.numberFormat(fieldStats);
 
       p.text = {template: '{{' + e.fieldRef(TEXT) + ' | number:\'' +
         numberFormat +'\'}}'};
-      p.align = {value: textField.align};
+      p.align = {value: field.align};
     } else {
       p.text = {field: e.fieldRef(TEXT)};
     }
   } else {
-    p.text = {value: textField.placeholder};
+    p.text = {value: field.placeholder};
   }
 
-  p.font = {value: textField.font.family};
-  p.fontWeight = {value: textField.font.weight};
-  p.fontStyle = {value: textField.font.style};
-  p.baseline = {value: textField.baseline};
+  p.font = {value: field.font.family};
+  p.fontWeight = {value: field.font.weight};
+  p.fontStyle = {value: field.font.style};
+  p.baseline = {value: field.baseline};
 
   return p;
 }

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -455,7 +455,7 @@ function text_props(e, layout, style, stats) {
   if (e.has(TEXT)) {
     if (e.isType(TEXT, Q)) {
       var fieldStats = stats[e.fieldName(name)],
-        numberFormat = e.numberFormat(name, fieldStats);
+        numberFormat = textField.format || e.numberFormat(fieldStats);
 
       p.text = {template: '{{' + e.fieldRef(TEXT) + ' | number:\'' +
         numberFormat +'\'}}'};

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -27,7 +27,7 @@ scale.defs = function(names, encoding, layout, stats, style, sorting, opt) {
 
     s.sort = scale.sort(s, encoding, name) || undefined;
 
-    scale.range(s, encoding, layout, stats, style, opt);
+    scale.range(s, encoding, layout, stats, opt);
 
     return (a.push(s), a);
   }, []);
@@ -104,10 +104,10 @@ scale.domain = function (name, encoding, stats, sorting, opt) {
 };
 
 
-scale.range = function (s, encoding, layout, stats, style, opt) {
-  // jshint unused:false
+scale.range = function (s, encoding, layout, stats) {
   var spec = encoding.scale(s.name),
-    timeUnit = encoding.field(s.name).timeUnit;
+    field = encoding.field(s.name),
+    timeUnit = field.timeUnit;
 
   switch (s.name) {
     case X:
@@ -125,16 +125,19 @@ scale.range = function (s, encoding, layout, stats, style, opt) {
       }
       s.round = true;
       if (s.type === 'time') {
-        s.nice = timeUnit;
+        s.nice = timeUnit || encoding.config('timeScaleNice');
       }else {
         s.nice = true;
       }
       break;
     case Y:
-      s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
       if (s.type === 'ordinal') {
+        s.range = layout.cellHeight ?
+          (field.bin ? [layout.cellHeight, 0] : [0, layout.cellHeight]) :
+          'height';
         s.bandWidth = encoding.bandSize(Y, layout.y.useSmallBand);
       } else {
+        s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
         if (encoding.isType(s.name,T) && timeUnit === 'year') {
           s.zero = false;
         } else {

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -23,11 +23,11 @@ scale.defs = function(names, encoding, layout, stats, style, sorting, opt) {
       type: scale.type(name, encoding),
       domain: scale.domain(name, encoding, sorting, opt)
     };
-    if (s.type === 'ordinal' && !encoding.bin(name) && encoding.sort(name).length === 0) {
-      s.sort = true;
-    }
 
-    scale_range(s, encoding, layout, stats, style, opt);
+    s.sort = s.type === 'ordinal' && (
+        encoding.bin(name) ||
+        encoding.sort(name).length === 0
+      );
 
     return (a.push(s), a);
   }, []);
@@ -90,11 +90,10 @@ function scale_range(s, encoding, layout, stats, style, opt) {
 
   switch (s.name) {
     case X:
+      s.range = layout.cellWidth ? [0, layout.cellWidth] : 'width';
       if (s.type === 'ordinal') {
         s.bandWidth = encoding.bandSize(X, layout.x.useSmallBand);
       } else {
-        s.range = layout.cellWidth ? [0, layout.cellWidth] : 'width';
-
         if (encoding.isType(s.name,T) && timeUnit === 'year') {
           s.zero = false;
         } else {
@@ -111,11 +110,10 @@ function scale_range(s, encoding, layout, stats, style, opt) {
       }
       break;
     case Y:
+      s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
       if (s.type === 'ordinal') {
         s.bandWidth = encoding.bandSize(Y, layout.y.useSmallBand);
       } else {
-        s.range = layout.cellHeight ? [layout.cellHeight, 0] : 'height';
-
         if (encoding.isType(s.name,T) && timeUnit === 'year') {
           s.zero = false;
         } else {

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -24,13 +24,19 @@ scale.defs = function(names, encoding, layout, stats, style, sorting, opt) {
       domain: scale.domain(name, encoding, sorting, opt)
     };
 
-    s.sort = s.type === 'ordinal' && (
-        encoding.bin(name) ||
-        encoding.sort(name).length === 0
-      );
+    s.sort = scale.sort(s, encoding, name) || undefined;
+
+    scale.range(s, encoding, layout, stats, style, opt);
 
     return (a.push(s), a);
   }, []);
+};
+
+scale.sort = function(s, encoding, name) {
+  return s.type === 'ordinal' && (
+    !!encoding.bin(name) ||
+    encoding.sort(name).length === 0
+  );
 };
 
 scale.type = function(name, encoding) {
@@ -83,7 +89,7 @@ scale.domain = function (name, encoding, sorting, opt) {
 };
 
 
-function scale_range(s, encoding, layout, stats, style, opt) {
+scale.range = function (s, encoding, layout, stats, style, opt) {
   // jshint unused:false
   var spec = encoding.scale(s.name),
     timeUnit = encoding.field(s.name).timeUnit;
@@ -181,7 +187,7 @@ function scale_range(s, encoding, layout, stats, style, opt) {
         s.padding = encoding.field(s.name).band.padding;
       }
   }
-}
+};
 
 scale.color = function(s, encoding, stats) {
   var colorScale = encoding.scale(COLOR),

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -85,7 +85,9 @@ scale.domain = function (name, encoding, stats, sorting, opt) {
   }
   var aggregate = encoding.aggregate(name),
     timeUnit = field.timeUnit,
-    useRawDomain = encoding.scale(name).useRawDomain,
+    scaleUseRawDomain = encoding.scale(name).useRawDomain,
+    useRawDomain = scaleUseRawDomain !== undefined ?
+      scaleUseRawDomain : encoding.config('useRawDomain'),
     notCountOrSum = !aggregate || (aggregate !=='count' && aggregate !== 'sum');
 
   if ( useRawDomain && notCountOrSum && (

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -97,7 +97,7 @@ scale.domain = function (name, encoding, stats, sorting, opt) {
       (encoding.isType(name, T) && (!timeUnit || !time.isOrdinalFn(timeUnit)))
     )
   ) {
-    return {data: RAW, field: encoding.fieldRef(name, {nofn: true})};
+    return {data: RAW, field: encoding.fieldRef(name, {nofn: !timeUnit})};
   }
 
   return {data: sorting.getDataset(name), field: encoding.fieldRef(name)};

--- a/src/compiler/time.js
+++ b/src/compiler/time.js
@@ -34,12 +34,11 @@ function time(spec, encoding) { // FIXME refactor to reduce side effect #276
   // add scales
   var scales = spec.scales = spec.scales || [];
   for (var timeUnit in timeUnits) {
-    time.scale(scales, timeUnit, encoding);
+    var scale = time.scale.def(timeUnit, encoding);
+    if (scale) scales.push(scale);
   }
   return spec;
 }
-
-
 
 time.cardinality = function(field, stats, filterNull, type) {
   var timeUnit = field.timeUnit;
@@ -63,7 +62,7 @@ time.cardinality = function(field, stats, filterNull, type) {
   return null;
 };
 
-time.maxLength = function(timeUnit, timeFormat) {
+time.maxLength = function(timeUnit, encoding) {
   switch (timeUnit) {
     case 'seconds':
     case 'minutes':
@@ -72,10 +71,17 @@ time.maxLength = function(timeUnit, timeFormat) {
       return 2;
     case 'month':
     case 'day':
-      return 9; // September / Wednesday
+      var range = time.range(timeUnit, encoding);
+      if (range) {
+        // return the longest name in the range
+        return Math.max.apply(null, range.map(function(r) {return r.length;}));
+      }
+      return 2;
     case 'year':
       return 4; //'1998'
   }
+  // no time unit
+  var timeFormat = encoding.config('timeFormat');
   return d3_time_format.utcFormat(timeFormat)(LONG_DATE).length;
 };
 
@@ -99,32 +105,41 @@ time.transform = function(transform, encoding, encType, field) {
   });
 };
 
-/** append custom time scales for axis label */
-time.scale = function(scales, timeUnit, encoding) {
-  var labelLength = encoding.config('timeScaleLabelLength');
-  // TODO add option for shorter scale / custom range
+time.range = function(timeUnit, encoding) {
+  var labelLength = encoding.config('timeScaleLabelLength'),
+    scaleLabel;
   switch (timeUnit) {
     case 'day':
-      scales.push({
-        name: 'time-'+timeUnit,
-        type: 'ordinal',
-        domain: util.range(0, 7),
-        range: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'].map(
-          function(s) { return s.substr(0, labelLength);}
-        )
-      });
+      scaleLabel = encoding.config('dayScaleLabel');
       break;
     case 'month':
-      scales.push({
-        name: 'time-'+timeUnit,
-        type: 'ordinal',
-        domain: util.range(0, 12),
-        range: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'].map(
-            function(s) { return s.substr(0, labelLength);}
-          )
-      });
+      scaleLabel = encoding.config('monthScaleLabel');
       break;
   }
+  if (scaleLabel) {
+    return labelLength ? scaleLabel.map(
+        function(s) { return s.substr(0, labelLength);}
+      ) : scaleLabel;
+  }
+  return;
+};
+
+
+time.scale = {};
+
+/** append custom time scales for axis label */
+time.scale.def = function(timeUnit, encoding) {
+  var range = time.range(timeUnit, encoding);
+
+  if (range) {
+    return {
+      name: 'time-'+timeUnit,
+      type: 'ordinal',
+      domain: time.scale.domain(timeUnit),
+      range: range
+    };
+  }
+  return null;
 };
 
 time.isOrdinalFn = function(timeUnit) {

--- a/src/compiler/time.js
+++ b/src/compiler/time.js
@@ -1,8 +1,11 @@
 'use strict';
 
-var util = require('../util');
+var util = require('../util'),
+  d3_time_format = require('d3-time-format');
 
 module.exports = time;
+
+var LONG_DATE = new Date(2014, 8, 17);
 
 function time(spec, encoding) { // FIXME refactor to reduce side effect #276
   // jshint unused:false
@@ -58,6 +61,22 @@ time.cardinality = function(field, stats, filterNull, type) {
   }
 
   return null;
+};
+
+time.maxLength = function(timeUnit, timeFormat) {
+  switch (timeUnit) {
+    case 'seconds':
+    case 'minutes':
+    case 'hours':
+    case 'date':
+      return 2;
+    case 'month':
+    case 'day':
+      return 9; // September / Wednesday
+    case 'year':
+      return 4; //'1998'
+  }
+  return d3_time_format.utcFormat(timeFormat)(LONG_DATE).length;
 };
 
 function fieldFn(func, field) {

--- a/src/compiler/time.js
+++ b/src/compiler/time.js
@@ -4,7 +4,7 @@ var util = require('../util');
 
 module.exports = time;
 
-function time(spec, encoding, opt) { // FIXME refactor to reduce side effect #276
+function time(spec, encoding) { // FIXME refactor to reduce side effect #276
   // jshint unused:false
   var timeFields = {}, timeUnits = {};
 
@@ -20,7 +20,7 @@ function time(spec, encoding, opt) { // FIXME refactor to reduce side effect #27
   });
 
   // add formula transform
-  var data = spec.data[1],
+  var data = spec.data[0],
     transform = data.transform = data.transform || [];
 
   for (var f in timeFields) {

--- a/src/data.js
+++ b/src/data.js
@@ -21,5 +21,10 @@ vldata.stats = function(data) {
   return summary.reduce(function(s, profile) {
     s[profile.field] = profile;
     return s;
-  }, {count: data.length});
+  }, {
+    '*': {
+      max: data.length,
+      min: 0
+    }
+  });
 };

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -661,20 +661,20 @@ var config = {
     },
     maxSmallNumber: {
       type: 'number',
-      default: 1000,
+      default: 10000,
       description: 'maximum number that a field will be considered smallNumber.'+
                    'Used for axis labelling.'
     },
     smallNumberFormat: {
       type: 'string',
-      default: ',g',
-      description: 'Number format for axis labels and text tables '+
+      default: '',
+      description: 'D3 Number format for axis labels and text tables '+
                    'for number <= maxSmallNumber. Used for axis labelling.'
     },
     largeNumberFormat: {
       type: 'string',
       default: '.3s',
-      description: 'Number format for axis labels and text tables ' +
+      description: 'D3 Number format for axis labels and text tables ' +
                    'for number > maxSmallNumber.'
     },
     timeFormat: {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -635,7 +635,24 @@ var config = {
     timeScaleLabelLength: {
       type: 'integer',
       default: 3,
-      minimum: 0
+      minimum: 0,
+      description: 'Max length for values in dayScaleLabel and monthScaleLabel.  Zero means using full names in dayScaleLabel/monthScaleLabel.'
+    },
+    dayScaleLabel: {
+      type: 'array',
+      items: {
+        type: 'string'
+      },
+      default: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+      description: 'Axis labels for day of week, starting from Monday.'
+    },
+    monthScaleLabel: {
+      type: 'array',
+      items: {
+        type: 'string'
+      },
+      default: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+      description: 'Axis labels for month.'
     },
     // other
     characterWidth: {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -167,20 +167,16 @@ var axisMixin = {
         format: {
           type: 'string',
           default: undefined,  // auto
-          description: 'The formatting pattern for axis labels.'
+          description: 'The formatting pattern for axis labels. '+
+                       'If not undefined, this will be determined by ' +
+                       'small/largeNumberFormat and the max value ' +
+                       'of the field.'
         },
         maxLabelLength: {
           type: 'integer',
           default: 25,
           minimum: 0,
           description: 'Truncate labels that are too long.'
-        },
-        numberFormat: {
-          type: 'string',
-          default: undefined,
-          description: 'Number format for the axis.  If not undefined, this will ' +
-                       'be determined by small/largeNumberFormat and the max value ' +
-                       'of the field.'
         }
       }
     }
@@ -295,7 +291,15 @@ var textMixin = {
           enum: ['normal', 'italic']
         }
       }
-    }
+    },
+    format: {
+      type: 'string',
+      default: undefined,  // auto
+      description: 'The formatting pattern for text value. '+
+                   'If not undefined, this will be determined by ' +
+                   'small/largeNumberFormat and the max value ' +
+                   'of the field.'
+    },
   }
 };
 

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -110,11 +110,12 @@ var typicalField = merge(clone(schema.field), {
         },
         useRawDomain: {
           type: 'boolean',
-          default: false,
+          default: undefined,
           description: 'Use the raw data range as scale domain instead of ' +
                        'aggregated data for aggregate axis. ' +
                        'This option does not work with sum or count aggregate' +
-                       'as they might have a substantially larger scale range.'
+                       'as they might have a substantially larger scale range.' +
+                       'By default, use value in the config.useRawDomain.'
         }
       }
     }
@@ -663,6 +664,15 @@ var config = {
       type: 'string',
       default: '%Y-%m-%d',
       description: 'Date format for axis labels.'
+    },
+    useRawDomain: {
+      type: 'boolean',
+      default: false,
+      description: 'Use the raw data range as scale domain instead of ' +
+                   'aggregated data for aggregate axis. ' +
+                   'This option does not work with sum or count aggregate' +
+                   'as they might have a substantially larger scale range.' +
+                   'By default, use value in the config.useRawDomain.'
     }
   }
 };

--- a/test/compiler/axis.spec.js
+++ b/test/compiler/axis.spec.js
@@ -25,7 +25,7 @@ describe('Axis', function() {
       y: {
         axisTitleOffset: 60
       }
-    });
+    }, {a: {}});
 
     //FIXME decouple the test here
 

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -39,7 +39,7 @@ describe('vl.compile.scale', function() {
             name: 'origin'
           }
         }
-      }), {}, {
+      }), {}, {}, {
         stack: 'y',
         facet: true
       });
@@ -58,7 +58,7 @@ describe('vl.compile.scale', function() {
             name: 'origin'
           }
         }
-      }), {}, {
+      }), {}, {}, {
         stack: 'y',
         facet: true
       });
@@ -74,15 +74,15 @@ describe('vl.compile.scale', function() {
         var domain = vlscale.domain('y', Encoding.fromSpec({
           encoding: {
             y: {
-              bin: true,
+              bin: {maxbins: 15},
               name: 'origin',
               scale: {useRawDomain: true},
               type: Q
             }
           }
-        }), sorting, {});
+        }), {origin: {min: -5, max:48}}, sorting, {});
 
-        expect(domain.data).to.eql(sortingReturn);
+        expect(domain).to.eql([-5, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45]);
       });
 
     it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
@@ -96,7 +96,7 @@ describe('vl.compile.scale', function() {
               type: Q
             }
           }
-        }), {}, {});
+        }), {}, {}, {});
 
         expect(domain.data).to.eql(RAW);
       });
@@ -112,7 +112,7 @@ describe('vl.compile.scale', function() {
               type: Q
             }
           }
-        }), sorting, {});
+        }), {}, sorting, {});
 
         expect(domain.data).to.eql(sortingReturn);
       });
@@ -127,7 +127,7 @@ describe('vl.compile.scale', function() {
               type: T
             }
           }
-        }), {}, {});
+        }), {}, {}, {});
 
         expect(domain.data).to.eql(RAW);
       });
@@ -143,7 +143,7 @@ describe('vl.compile.scale', function() {
               timeUnit: 'year'
             }
           }
-        }), {}, {});
+        }), {}, {}, {});
 
         expect(domain.data).to.eql(RAW);
       });
@@ -159,7 +159,7 @@ describe('vl.compile.scale', function() {
               timeUnit: 'month'
             }
           }
-        }), sorting, {});
+        }), {}, sorting, {});
 
         expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
       });
@@ -174,7 +174,7 @@ describe('vl.compile.scale', function() {
             type: Q
           }
         }
-      }), sorting, {});
+      }),  {}, sorting, {});
 
       expect(domain.data).to.eql(sortingReturn);
     });

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -146,6 +146,7 @@ describe('vl.compile.scale', function() {
         }), {}, {}, {});
 
         expect(domain.data).to.eql(RAW);
+        expect(domain.field.indexOf('year')).to.gt(-1);
       });
 
     it('should return the correct domain for month T',

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -8,89 +8,169 @@ var util = require('../../src/util'),
   vlscale = require('../../src/compiler/scale'),
   colorbrewer = require('colorbrewer');
 
-describe('vl.compile.scale.domain()', function() {
-  var sortingReturn = 'sorted',
-    sorting = {
-      getDataset: function() {return 'sorted';}
-    };
+describe('vl.compile.scale', function() {
+  describe('sort()', function() {
+    it('should return true for any ordinal or binned field', function() {
+      var encoding = Encoding.fromSpec({
+          encoding: {
+            x: { name: 'origin', type: O},
+            y: { bin: true, name: 'origin', type: Q}
+          }
+        });
 
-  it('should return correct stack', function() {
-    var domain = vlscale.domain('y', Encoding.fromSpec({
-      encoding: {
-        y: {
-          name: 'origin'
-        }
-      }
-    }), {}, {
-      stack: 'y',
-      facet: true
+      expect(vlscale.sort({type: 'ordinal'}, encoding, 'x'))
+        .to.eql(true);
+      expect(vlscale.sort({type: 'ordinal'}, encoding, 'y'))
+        .to.eql(true);
     });
 
-    expect(domain).to.eql({
-      data: 'stacked',
-      field: 'data.max_sum_origin'
-    });
   });
 
-  it('should return correct aggregated stack', function() {
-    var domain = vlscale.domain('y', Encoding.fromSpec({
-      encoding: {
-        y: {
-          aggregate: 'sum',
-          name: 'origin'
-        }
-      }
-    }), {}, {
-      stack: 'y',
-      facet: true
-    });
+  describe('domain()', function() {
+    var sortingReturn = 'sorted',
+      sorting = {
+        getDataset: function() {return 'sorted';}
+      };
 
-    expect(domain).to.eql({
-      data: 'stacked',
-      field: 'data.max_sum_sum_origin'
-    });
-  });
-
-  it('should return the right domain if binned Q',
-    function() {
+    it('should return correct stack', function() {
       var domain = vlscale.domain('y', Encoding.fromSpec({
         encoding: {
           y: {
-            bin: true,
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: Q
+            name: 'origin'
           }
         }
-      }), sorting, {});
+      }), {}, {
+        stack: 'y',
+        facet: true
+      });
 
-      expect(domain.data).to.eql(sortingReturn);
+      expect(domain).to.eql({
+        data: 'stacked',
+        field: 'data.max_sum_origin'
+      });
     });
 
-  it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            aggregate: 'mean',
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: Q
-          }
-        }
-      }), {}, {});
-
-      expect(domain.data).to.eql(RAW);
-    });
-
-  it('should return the aggregate domain for sum Q',
-    function() {
+    it('should return correct aggregated stack', function() {
       var domain = vlscale.domain('y', Encoding.fromSpec({
         encoding: {
           y: {
             aggregate: 'sum',
+            name: 'origin'
+          }
+        }
+      }), {}, {
+        stack: 'y',
+        facet: true
+      });
+
+      expect(domain).to.eql({
+        data: 'stacked',
+        field: 'data.max_sum_sum_origin'
+      });
+    });
+
+    it('should return the right domain if binned Q',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              bin: true,
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: Q
+            }
+          }
+        }), sorting, {});
+
+        expect(domain.data).to.eql(sortingReturn);
+      });
+
+    it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              aggregate: 'mean',
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: Q
+            }
+          }
+        }), {}, {});
+
+        expect(domain.data).to.eql(RAW);
+      });
+
+    it('should return the aggregate domain for sum Q',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              aggregate: 'sum',
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: Q
+            }
+          }
+        }), sorting, {});
+
+        expect(domain.data).to.eql(sortingReturn);
+      });
+
+    it('should return the raw domain if useRawDomain is true for raw T',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: T
+            }
+          }
+        }), {}, {});
+
+        expect(domain.data).to.eql(RAW);
+      });
+
+    it('should return the raw domain if useRawDomain is true for year T',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: T,
+              timeUnit: 'year'
+            }
+          }
+        }), {}, {});
+
+        expect(domain.data).to.eql(RAW);
+      });
+
+    it('should return the correct domain for month T',
+      function() {
+        var domain = vlscale.domain('y', Encoding.fromSpec({
+          encoding: {
+            y: {
+              name: 'origin',
+              scale: {useRawDomain: true},
+              type: T,
+              timeUnit: 'month'
+            }
+          }
+        }), sorting, {});
+
+        expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+      });
+
+    it('should return the aggregated domain if useRawDomain is false', function() {
+      var domain = vlscale.domain('y', Encoding.fromSpec({
+        encoding: {
+          y: {
+            aggregate: 'min',
             name: 'origin',
-            scale: {useRawDomain: true},
+            scale: {useRawDomain: false},
             type: Q
           }
         }
@@ -99,127 +179,66 @@ describe('vl.compile.scale.domain()', function() {
       expect(domain.data).to.eql(sortingReturn);
     });
 
-  it('should return the raw domain if useRawDomain is true for raw T',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: T
-          }
-        }
-      }), {}, {});
-
-      expect(domain.data).to.eql(RAW);
-    });
-
-  it('should return the raw domain if useRawDomain is true for year T',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: T,
-            timeUnit: 'year'
-          }
-        }
-      }), {}, {});
-
-      expect(domain.data).to.eql(RAW);
-    });
-
-  it('should return the correct domain for month T',
-    function() {
-      var domain = vlscale.domain('y', Encoding.fromSpec({
-        encoding: {
-          y: {
-            name: 'origin',
-            scale: {useRawDomain: true},
-            type: T,
-            timeUnit: 'month'
-          }
-        }
-      }), sorting, {});
-
-      expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-    });
-
-  it('should return the aggregated domain if useRawDomain is false', function() {
-    var domain = vlscale.domain('y', Encoding.fromSpec({
-      encoding: {
-        y: {
-          aggregate: 'min',
-          name: 'origin',
-          scale: {useRawDomain: false},
-          type: Q
-        }
-      }
-    }), sorting, {});
-
-    expect(domain.data).to.eql(sortingReturn);
+    // TODO test other cases
   });
 
-  // TODO test other cases
-});
+  describe('color.palette', function() {
+    it('should return tableau categories', function() {
+      expect(vlscale.color.palette('category10k')).to.eql(
+        ['#2ca02c', '#e377c2', '#7f7f7f', '#17becf', '#8c564b', '#d62728', '#bcbd22',
+          '#9467bd', '#ff7f0e', '#1f77b4'
+        ]
+      );
+    });
 
-describe('vl.compile.scale.color.palette', function() {
-  it('should return tableau categories', function() {
-    expect(vlscale.color.palette('category10k')).to.eql(
-      ['#2ca02c', '#e377c2', '#7f7f7f', '#17becf', '#8c564b', '#d62728', '#bcbd22',
-        '#9467bd', '#ff7f0e', '#1f77b4'
-      ]
-    );
-  });
+    it('should return pre-defined brewer palette if low cardinality', function() {
+      var brewerPalettes = util.keys(colorbrewer);
+      brewerPalettes.forEach(function(palette) {
+        util.range(3, 9).forEach(function(cardinality) {
+          expect(vlscale.color.palette(palette, cardinality)).to.eql(
+            colorbrewer[palette][cardinality]
+          );
+        });
+      });
+    });
 
-  it('should return pre-defined brewer palette if low cardinality', function() {
-    var brewerPalettes = util.keys(colorbrewer);
-    brewerPalettes.forEach(function(palette) {
-      util.range(3, 9).forEach(function(cardinality) {
-        expect(vlscale.color.palette(palette, cardinality)).to.eql(
-          colorbrewer[palette][cardinality]
+    it('should return pre-defined brewer palette if high cardinality N', function() {
+      var brewerPalettes = util.keys(colorbrewer);
+      brewerPalettes.forEach(function(palette) {
+        var cardinality = 20;
+        expect(vlscale.color.palette(palette, cardinality, 'N')).to.eql(
+          colorbrewer[palette][Math.max.apply(null, util.keys(colorbrewer[palette]))]
+        );
+      });
+    });
+
+    it('should return interpolated scale if high cardinality ordinal', function() {
+      var brewerPalettes = util.keys(colorbrewer);
+      brewerPalettes.forEach(function(palette) {
+        var cardinality = 20,
+          ps = 5,
+          p = colorbrewer[palette],
+          interpolator = d3.interpolateLab(p[ps][0], p[ps][ps - 1]);
+        expect(vlscale.color.palette(palette, cardinality, 'O')).to.eql(
+          util.range(cardinality).map(function(i) {
+            return interpolator(i * 1.0 / (cardinality - 1));
+          })
         );
       });
     });
   });
 
-  it('should return pre-defined brewer palette if high cardinality N', function() {
-    var brewerPalettes = util.keys(colorbrewer);
-    brewerPalettes.forEach(function(palette) {
-      var cardinality = 20;
-      expect(vlscale.color.palette(palette, cardinality, 'N')).to.eql(
-        colorbrewer[palette][Math.max.apply(null, util.keys(colorbrewer[palette]))]
-      );
+  describe('color.interpolate', function() {
+    it('should interpolate color along the lab space', function() {
+      var interpolator = d3.interpolateLab('#ffffff', '#000000'),
+        cardinality = 8;
+
+      expect(vlscale.color.interpolate('#ffffff', '#000000', cardinality))
+        .to.eql(
+          util.range(cardinality).map(function(i) {
+            return interpolator(i * 1.0 / (cardinality - 1));
+          })
+        );
     });
-  });
-
-  it('should return interpolated scale if high cardinality ordinal', function() {
-    var brewerPalettes = util.keys(colorbrewer);
-    brewerPalettes.forEach(function(palette) {
-      var cardinality = 20,
-        ps = 5,
-        p = colorbrewer[palette],
-        interpolator = d3.interpolateLab(p[ps][0], p[ps][ps - 1]);
-      expect(vlscale.color.palette(palette, cardinality, 'O')).to.eql(
-        util.range(cardinality).map(function(i) {
-          return interpolator(i * 1.0 / (cardinality - 1));
-        })
-      );
-    });
-  });
-});
-
-describe('vl.compile.scale.color.interpolate', function() {
-  it('should interpolate color along the lab space', function() {
-    var interpolator = d3.interpolateLab('#ffffff', '#000000'),
-      cardinality = 8;
-
-    expect(vlscale.color.interpolate('#ffffff', '#000000', cardinality))
-      .to.eql(
-        util.range(cardinality).map(function(i) {
-          return interpolator(i * 1.0 / (cardinality - 1));
-        })
-      );
   });
 });

--- a/test/compiler/stack.spec.js
+++ b/test/compiler/stack.spec.js
@@ -3,18 +3,7 @@
 var expect = require('chai').expect;
 var fixtures = require('../fixtures').stack;
 
-var compile = require('../../src/vl').compile,
-  util = require('../../src/util');
-
-// mock util.getbins()
-util.getbins = function() {
-  return {
-    start: 0,
-    stop: 10,
-    step: 1
-  };
-};
-
+var compile = require('../../src/vl').compile;
 
 var stats = {
   'Cost__Total_$': {

--- a/test/compiler/time.spec.js
+++ b/test/compiler/time.spec.js
@@ -16,7 +16,7 @@ describe('Time', function() {
     spec = time({data: [{name: RAW}, {name: TABLE}]}, encoding, {});
 
   it('should add formula transform', function() {
-    var data = spec.data[1];
+    var data = spec.data[0];
     expect(data.transform).to.be.ok;
 
     expect(data.transform.filter(function(t) {

--- a/test/compiler/time.spec.js
+++ b/test/compiler/time.spec.js
@@ -33,8 +33,29 @@ describe('time', function() {
 
   describe('maxLength', function(){
     it('should return max length based on time format', function () {
-      expect(time.maxLength(undefined, '%A %B %e %H:%M:%S %Y'))
+      expect(time.maxLength(undefined /*no timeUnit*/, {
+          config: function(){ return '%A %B %e %H:%M:%S %Y';}
+        }))
         .to.eql('Wednesday September 17 04:00:00 2014'.length);
+    });
+
+    it('should return max length of the month custom scale', function () {
+      expect(time.maxLength('month', Encoding.fromSpec({mark: 'point'})))
+        .to.eql(3);
+    });
+
+    it('should return max length of the day custom scale', function () {
+      expect(time.maxLength('day', Encoding.fromSpec({mark: 'point'})))
+        .to.eql(3);
+    });
+
+    it.only('should return max length of the month custom scale', function () {
+      expect(time.maxLength('month', Encoding.fromSpec({
+        mark: 'point',
+        config: {
+          timeScaleLabelLength: 0
+        }
+      }))).to.eql(9);
     });
   });
 });

--- a/test/compiler/time.spec.js
+++ b/test/compiler/time.spec.js
@@ -49,7 +49,7 @@ describe('time', function() {
         .to.eql(3);
     });
 
-    it.only('should return max length of the month custom scale', function () {
+    it('should return max length of the month custom scale', function () {
       expect(time.maxLength('month', Encoding.fromSpec({
         mark: 'point',
         config: {

--- a/test/compiler/time.spec.js
+++ b/test/compiler/time.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 var time = require('../../src/compiler/time'),
   Encoding = require('../../src/Encoding');
 
-describe('Time', function() {
+describe('time', function() {
   var fieldName = 'a',
     timeUnit = 'month',
     encoding = Encoding.fromSpec({
@@ -29,5 +29,12 @@ describe('Time', function() {
     expect(spec.scales.filter(function(scale) {
       return scale.name == 'time-'+ timeUnit;
     }).length).to.equal(1);
+  });
+
+  describe('maxLength', function(){
+    it('should return max length based on time format', function () {
+      expect(time.maxLength(undefined, '%A %B %e %H:%M:%S %Y'))
+        .to.eql('Wednesday September 17 04:00:00 2014'.length);
+    });
   });
 });

--- a/test/field.spec.js
+++ b/test/field.spec.js
@@ -20,7 +20,7 @@ describe('vl.field.cardinality()', function () {
       var field = {name:2, type:'Q', bin: {maxbins: 15}};
       var stats = {2:{distinct: 10, min:0, max:150}};
       var cardinality = vlfield.cardinality(field, stats);
-      expect(cardinality).to.equal(10);
+      expect(cardinality).to.equal(15);
     });
   });
 });


### PR DESCRIPTION
Please merge #507 first.  [See Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/useRawDomain-config...kw/axisLabelOffset)

- make better offset for timeAxis 
   - `month`/`day`
   - for raw time —  take `timeFormat` into account
   - Q
   - special case for ordinal based on number
- remove redundant `numberFormat` config in axis and add `format` to textMixin
- add `dayScaleLabel`, `monthScaleLabel`

- refactor `time.js`

- refactor layout.offset

- add `vl.data.stats`

- add some tests