### PR TITLE
Fix Missing text tables, simplify a few things

### DIFF
--- a/gallery/gallery.js
+++ b/gallery/gallery.js
@@ -66,7 +66,7 @@ var EXAMPLES = [
           name: 'variety'
         },
         row: {type: 'O',name: 'site'},
-        color: {type: 'O',name: 'year'}
+        color: {type: 'N',name: 'year'}
       }
     }
   },{
@@ -107,7 +107,7 @@ var EXAMPLES = [
       'data': {'url': 'data/movies.json'}
     }
   },{
-    title: 'Text heatmap',
+    title: 'Text Heatmap',
     spec: {
       'marktype': 'text',
       'encoding': {

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -58,8 +58,7 @@ compiler.compileEncoding = function (encoding, stats) {
   // marks
   var style = compiler.style(encoding, stats),
     group = spec.marks[0],
-    mark = marks[encoding.marktype()],
-    mdefs = marks.def(mark, encoding, layout, style, stats),
+    mdefs = marks.def(encoding, layout, style, stats),
     mdef = mdefs[mdefs.length - 1];  // TODO: remove this dirty hack by refactoring the whole flow
 
   for (var i = 0; i < mdefs.length; i++) {

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -87,6 +87,7 @@ compiler.compileEncoding = function (encoding, stats) {
     mdef.from.transform = [{type: 'sort', by: '-' + encoding.fieldRef(f)}];
   }
 
+  // get a flattened list of all scale names that are used in the vl spec
   var singleScaleNames = [].concat.apply([], mdefs.map(function(markProps) {
     return scale.names(markProps.properties.update);
   }));

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -88,12 +88,16 @@ compiler.compileEncoding = function (encoding, stats) {
     mdef.from.transform = [{type: 'sort', by: '-' + encoding.fieldRef(f)}];
   }
 
+  var singleScaleNames = [].concat.apply([], mdefs.map(function(markProps) {
+    return scale.names(markProps.properties.update);
+  }));
+
   // Small Multiples
   if (encoding.has(ROW) || encoding.has(COL)) {
-    spec = compiler.facet(group, encoding, layout, style, sorting, spec, mdef, stack, stats);
+    spec = compiler.facet(group, encoding, layout, style, sorting, spec, singleScaleNames, stack, stats);
     spec.legends = legend.defs(encoding, style);
   } else {
-    group.scales = scale.defs(scale.names(mdef.properties.update), encoding, layout, stats, style, sorting, {stack: stack});
+    group.scales = scale.defs(singleScaleNames, encoding, layout, stats, style, sorting, {stack: stack});
     group.axes = axis.defs(axis.names(mdef.properties.update), encoding, layout, stats);
     group.legends = legend.defs(encoding, style);
   }

--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -10,7 +10,7 @@ var axis = require('./axis'),
 
 module.exports = faceting;
 
-function faceting(group, encoding, layout, style, sorting, spec, mdef, stack, stats) {
+function faceting(group, encoding, layout, style, sorting, spec, singleScaleNames, stack, stats) {
   var enter = group.properties.enter;
   var facetKeys = [], cellAxes = [], from, axesGrp;
 
@@ -98,7 +98,7 @@ function faceting(group, encoding, layout, style, sorting, spec, mdef, stack, st
   // assuming equal cellWidth here
   // TODO: support heterogenous cellWidth (maybe by using multiple scales?)
   spec.scales = (spec.scales || []).concat(scale.defs(
-    scale.names(enter).concat(scale.names(mdef.properties.update)),
+    scale.names(enter).concat(singleScaleNames),
     encoding,
     layout,
     stats,

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -4,8 +4,10 @@ require('../globals');
 
 var marks = module.exports = {};
 
-marks.def = function(mark, encoding, layout, style, stats) {
-  var defs = [];
+marks.def = function(encoding, layout, style, stats) {
+
+  var defs = [],
+    mark = marks[encoding.marktype()];
 
   // to add a background to text, we need to add it before the text
   if (encoding.marktype() === TEXT && encoding.has(COLOR)) {

--- a/src/compiler/template.js
+++ b/src/compiler/template.js
@@ -10,6 +10,7 @@ module.exports = template;
 function template(encoding, layout, stats) {
   // jshint unused:false
 
+  // TODO(kanitw): Jul 22, 2015 - split this file into data and template
   var data = {name: RAW, format: {}},
     table = {name: TABLE, source: RAW},
     dataUrl = encoding.data('url'),


### PR DESCRIPTION
- Remove `mdef` from `scales.def` and  `facet`
- fixes missing text tables
- simplify marks.def