### PR TITLE
eliminate axis.names(), axis.defs()

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -155,15 +155,10 @@ module.exports = (function() {
     return this._enc[et].scale || {};
   };
 
-  proto.axis = function(et) {
-    return this._enc[et].axis || {};
   };
 
-  proto.axes = function() {
-    var axes = [];
-    if (this.has(X)) axes.push('x');
-    if (this.has(Y)) axes.push('y');
-    return axes;
+  proto.axis = function(et) {
+    return this._enc[et].axis || {};
   };
 
   proto.bandSize = function(encType, useSmallBand) {

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -155,8 +155,6 @@ module.exports = (function() {
     return this._enc[et].scale || {};
   };
 
-  };
-
   proto.axis = function(et) {
     return this._enc[et].axis || {};
   };

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -159,6 +159,13 @@ module.exports = (function() {
     return this._enc[et].axis || {};
   };
 
+  proto.axes = function() {
+    var axes = [];
+    if (this.has(X)) axes.push('x');
+    if (this.has(Y)) axes.push('y');
+    return axes;
+  };
+
   proto.bandSize = function(encType, useSmallBand) {
     useSmallBand = useSmallBand ||
       //isBandInSmallMultiples

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -9,14 +9,6 @@ var util = require('../util'),
 
 var axis = module.exports = {};
 
-axis.defs = function(encoding, layout, stats, opt) {
-  var names = encoding.axes();
-  return names.reduce(function(a, name) {
-    a.push(axis.def(name, encoding, layout, stats, opt));
-    return a;
-  }, []);
-};
-
 axis.def = function(name, encoding, layout, stats, opt) {
   var isCol = name == COL,
     isRow = name == ROW,

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -9,15 +9,8 @@ var util = require('../util'),
 
 var axis = module.exports = {};
 
-axis.names = function(props) {
-  return util.keys(util.keys(props).reduce(function(a, x) {
-    var s = props[x].scale;
-    if (s === X || s === Y) a[props[x].scale] = 1;
-    return a;
-  }, {}));
-};
-
-axis.defs = function(names, encoding, layout, stats, opt) {
+axis.defs = function(encoding, layout, stats, opt) {
+  var names = encoding.axes();
   return names.reduce(function(a, name) {
     a.push(axis.def(name, encoding, layout, stats, opt));
     return a;

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -97,7 +97,7 @@ compiler.compileEncoding = function (encoding, stats) {
     spec.legends = legend.defs(encoding, style);
   } else {
     group.scales = scale.defs(singleScaleNames, encoding, layout, stats, style, sorting, {stack: stack});
-    group.axes = axis.defs(axis.names(mdef.properties.update), encoding, layout, stats);
+    group.axes = axis.defs(encoding, layout, stats);
     group.legends = legend.defs(encoding, style);
   }
 

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -98,7 +98,11 @@ compiler.compileEncoding = function (encoding, stats) {
     spec.legends = legend.defs(encoding, style);
   } else {
     group.scales = scale.defs(singleScaleNames, encoding, layout, stats, style, sorting, {stack: stack});
-    group.axes = axis.defs(encoding, layout, stats);
+
+    group.axes = [];
+    if (encoding.has(X)) group.axes.push(axis.def(X, encoding, layout, stats));
+    if (encoding.has(Y)) group.axes.push(axis.def(Y, encoding, layout, stats));
+
     group.legends = legend.defs(encoding, style);
   }
 

--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -47,7 +47,7 @@ function faceting(group, encoding, layout, style, sorting, spec, singleScaleName
     }
 
     axesGrp = groupdef('x-axes', {
-        axes: encoding.has(X) ? axis.defs(['x'], encoding, layout, stats) : undefined,
+        axes: encoding.has(X) ? [axis.def(X, encoding, layout, stats)] : undefined,
         x: hasCol ? {scale: COL, field: 'keys.0'} : {value: 0},
         width: hasCol && {'value': layout.cellWidth}, //HACK?
         from: from
@@ -55,11 +55,11 @@ function faceting(group, encoding, layout, style, sorting, spec, singleScaleName
 
     spec.marks.unshift(axesGrp); // need to prepend so it appears under the plots
     (spec.axes = spec.axes || []);
-    spec.axes.push.apply(spec.axes, axis.defs(['row'], encoding, layout, stats));
+    spec.axes.push(axis.def(ROW, encoding, layout, stats));
   } else { // doesn't have row
     if (encoding.has(X)) {
       //keep x axis in the cell
-      cellAxes.push.apply(cellAxes, axis.defs(['x'], encoding, layout, stats));
+      cellAxes.push(axis.def(X, encoding, layout, stats));
     }
   }
 
@@ -79,7 +79,7 @@ function faceting(group, encoding, layout, style, sorting, spec, singleScaleName
     }
 
     axesGrp = groupdef('y-axes', {
-      axes: encoding.has(Y) ? axis.defs(['y'], encoding, layout, stats) : undefined,
+      axes: encoding.has(Y) ? [axis.def(Y, encoding, layout, stats)] : undefined,
       y: hasRow && {scale: ROW, field: 'keys.0'},
       x: hasRow && {value: 0},
       height: hasRow && {'value': layout.cellHeight}, //HACK?
@@ -88,10 +88,10 @@ function faceting(group, encoding, layout, style, sorting, spec, singleScaleName
 
     spec.marks.unshift(axesGrp); // need to prepend so it appears under the plots
     (spec.axes = spec.axes || []);
-    spec.axes.push.apply(spec.axes, axis.defs(['col'], encoding, layout, stats));
+    spec.axes.push(axis.def(COL, encoding, layout, stats));
   } else { // doesn't have col
     if (encoding.has(Y)) {
-      cellAxes.push.apply(cellAxes, axis.defs(['y'], encoding, layout, stats));
+      cellAxes.push(axis.def(Y, encoding, layout, stats));
     }
   }
 


### PR DESCRIPTION
It’s actually very simple so I can’t resist to just kill them.  