### PR TITLE
A simple logger that preserves line number

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// TODO(kanitw): chat with Vega team and possibly move this to vega-loggger
+module.exports = function(prefix) {
+  // Borrowed some ideas from http://stackoverflow.com/a/15653260/866989
+  // and https://github.com/patik/console.log-wrapper/blob/master/consolelog.js
+  var METHODS = ['error', 'info', 'debug', 'warn', 'log'];
+
+  return METHODS.reduce(function(logger, fn) {
+    var cfn = console[fn] ? fn : 'log';
+    if (console[cfn].bind === 'undefined') { // IE < 10
+        logger[fn] = Function.prototype.bind.call(console[cfn], console, prefix);
+    }
+    else {
+        logger[fn] = console[cfn].bind(console, prefix);
+    }
+    return logger;
+  }, {});
+};

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// TODO(kanitw): chat with Vega team and possibly move this to vega-loggger
+// TODO(kanitw): chat with Vega team and possibly move this to vega-logging
 module.exports = function(prefix) {
   // Borrowed some ideas from http://stackoverflow.com/a/15653260/866989
   // and https://github.com/patik/console.log-wrapper/blob/master/consolelog.js

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,7 @@ var util = module.exports = require('datalib/src/util');
 
 util.extend(util, require('datalib/src/generate'));
 util.extend(util, require('datalib/src/stats'));
+util.extend(util, require('./logger')('[VL Error]'));
 util.bin = require('datalib/src/bins/bins');
 
 util.isin = function(item, array) {
@@ -97,9 +98,5 @@ util.getter = function(x, p, noaugment) {
     }
   }
   return x;
-};
-
-util.error = function(msg) {
-  console.error('[VL Error]', msg);
 };
 


### PR DESCRIPTION
Current logger function, which follow [vega-logging](https://github.com/vega/vega-logging)’s pattern does NOT show the right line number which is not particularly useful.  

Borrowing some ideas from stack overflow and some blog posts, this is a simple logger wrapper that still output the correct line number when `log`, `warn`, `error`, `info` or `debug` are called.  

cc: @arvind 