### PR TITLE
Add legend.title property and axis.labelAngle property

### DIFF
--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -25,10 +25,12 @@ axis.def = function(name, encoding, layout, stats, opt) {
   // Add axis label custom scale (for bin / time)
   def = axis.labels.scale(def, encoding, name);
   def = axis.labels.format(def, name, encoding, stats);
+  def = axis.labels.angle(def, encoding, name);
 
   // for x-axis, set ticks for Q or rotate scale for ordinal scale
   if (name == X) {
-    if (encoding.isDimension(X) || encoding.isType(X, T)) {
+    if ((encoding.isDimension(X) || encoding.isType(X, T)) &&
+        !('angle' in getter(def, ['properties', 'labels']))) {
       // TODO(kanitw): Jul 19, 2015 - #506 add condition for rotation
       def = axis.labels.rotate(def);
     } else { // Q
@@ -194,6 +196,14 @@ axis.labels.format = function (def, name, encoding, stats) {
       );
   }
 
+  return def;
+};
+
+axis.labels.angle = function(def, encoding, name) {
+  var angle = encoding.axis(name).labelAngle;
+  if (typeof angle === 'undefined') return def;
+
+  setter(def, ['properties', 'labels', 'angle', 'value'], angle);
   return def;
 };
 

--- a/src/compiler/legend.js
+++ b/src/compiler/legend.js
@@ -41,7 +41,7 @@ legend.defs = function(encoding, style) {
 legend.def = function(name, encoding, def, style) {
   var timeUnit = encoding.field(name).timeUnit;
 
-  def.title = encoding.fieldTitle(name);
+  def.title = legend.title(name, encoding);
   def = legend.style(name, encoding, def, style);
 
   if (encoding.isType(name, T) &&
@@ -101,4 +101,12 @@ legend.style = function(name, e, def, style) {
     symbols.opacity = {value: opacity};
   }
   return def;
+};
+
+legend.title = function(name, encoding) {
+  var leg = encoding.field(name).legend;
+
+  if (leg.title) return leg.title;
+
+  return encoding.fieldTitle(name);
 };

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -165,7 +165,7 @@ var axisMixin = {
           enum: ['top', 'right', 'left', 'bottom'],
           description: 'The orientation of the axis. One of top, bottom, left or right. The orientation can be used to further specialize the axis type (e.g., a y axis oriented for the right edge of the chart).'
         },
-        ticks :{
+        ticks: {
           type: 'integer',
           default: 5,
           description: 'A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale\'s range.'
@@ -198,7 +198,12 @@ var axisMixin = {
           default: 25,
           minimum: 0,
           description: 'Truncate labels that are too long.'
-        }
+        },
+        labelAngle: {
+          type: 'integer',
+          default: undefined, // auto
+          description: 'Angle by which to rotate labels. Set to 0 to force horizontal.'
+        },
       }
     }
   }

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -257,8 +257,14 @@ var legendMixin = {
   type: 'object',
   properties: {
     legend: {
-      type: 'boolean',
-      default: true
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+          default: undefined,
+          description: 'A title for the legend. (Shows field name and its function by default.)'
+        }
+      }
     }
   }
 };

--- a/test/compiler/axis.spec.js
+++ b/test/compiler/axis.spec.js
@@ -69,6 +69,17 @@ describe('Axis', function() {
     // FIXME(kanitw): Jul 19, 2015 - write test
   });
 
+  describe('labels.angle()', function () {
+    it('should set explicitly specified angle', function () {
+      var def = axis.labels.angle({}, Encoding.fromSpec({
+        encoding: {
+          x: {name: 'a', type: 'T', axis:{labelAngle: 90}}
+        }
+      }), 'x');
+      expect(def.properties.labels.angle).to.eql({value: 90});
+    });
+  });
+
   describe('labels.rotate()', function () {
     // FIXME(kanitw): Jul 19, 2015 - write test
   });

--- a/test/compiler/legend.spec.js
+++ b/test/compiler/legend.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var legend = require('../../src/compiler/legend'),
+  Encoding = require('../../src/Encoding');
+
+describe('Legend', function() {
+  describe('title()', function () {
+    it('should add explicitly specified title', function () {
+      var title = legend.title('color', Encoding.fromSpec({
+          encoding: {
+            color: {name: 'a', legend: {title: 'Custom'}}
+          }
+        }));
+      expect(title).to.eql('Custom');
+    });
+
+    it('should add return fieldTitle by default', function () {
+      var encoding = Encoding.fromSpec({
+          encoding: {
+            color: {name: 'a', legend: {}}
+          }
+        });
+
+      var title = legend.title('color', encoding);
+      expect(title).to.eql('a');
+    });
+  });
+});


### PR DESCRIPTION
See https://github.com/uwdata/vega-lite/issues/181.

Needed these for a project:
- had a computer-generated field with an ugly title that we didn't want in the legend, so added `legend.title`
- date labels were hard to read vertically so we wanted to force them horizontal, so added `axis.labelAngle`

Feedback welcome. Should maintain compatibility with existing specs.