### PR TITLE
Allow field sort to be explicitly disabled in line chart.

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -203,6 +203,8 @@ module.exports = (function() {
       isTypes = vlfield.isTypes;
 
     if ((!sort || sort.length===0) &&
+        // If sort is explicitly disabled in encoding, don't sort.
+        (sort !== false) &&
         // FIXME
         Encoding.toggleSort.support({encoding:this._enc}, stats, true) && //HACK
         this.config('toggleSort') === Q

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -84,12 +84,13 @@ compiler.compileEncoding = function (encoding, stats) {
   }
 
   // auto-sort line/area values
-  //TODO(kanitw): have some config to turn off auto-sort for line (for line chart that encodes temporal information)
   if (lineType) {
     var f = (encoding.isMeasure(X) && encoding.isDimension(Y)) ? Y : X;
-    if (!mdef.from) mdef.from = {};
-    // TODO: why - ?
-    mdef.from.transform = [{type: 'sort', by: '-' + encoding.fieldRef(f)}];
+    if (encoding.field(f).sort !== false) {
+      if (!mdef.from) mdef.from = {};
+      // TODO: why - ?
+      mdef.from.transform = [{type: 'sort', by: '-' + encoding.fieldRef(f)}];
+    }
   }
 
   // get a flattened list of all scale names that are used in the vl spec


### PR DESCRIPTION
related to #533 and #341? not sure if this is best way to do it (uneasy about mixing object/bool in `encoding.sort`), but I *really needed* this functionality.

I think sorting is a bad default, actually -- it's not hard to sort the data upfront before giving it to vega-lite, but it's impossible to go the other way if vega-lite forces it to be sorted.