### PR TITLE
allow disabling auto-sort for line

### DIFF
--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -84,8 +84,7 @@ compiler.compileEncoding = function (encoding, stats) {
   }
 
   // auto-sort line/area values
-  //TODO(kanitw): have some config to turn off auto-sort for line (for line chart that encodes temporal information)
-  if (lineType) {
+  if (lineType && encoding.config('autoSortLine')) {
     var f = (encoding.isMeasure(X) && encoding.isDimension(Y)) ? Y : X;
     if (!mdef.from) mdef.from = {};
     // TODO: why - ?

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -602,6 +602,10 @@ var config = {
       type: 'string',
       default: O
     },
+    autoSortLine: {
+      type: 'boolean',
+      default: true
+    },
 
     // single plot
     singleHeight: {


### PR DESCRIPTION
@osnr   Since you need it, I’m adding this as a config.    

Note that your PR #557 does not work because we declare sort properties to be `Array` type in the [JSON schema](https://github.com/uwdata/vega-lite/blob/master/src/schema/schema.js#L215) and therefore it can’t be `Boolean`.  

Please let me know if this works for you.  

Note that this is subject to change once we migrate to Vega 2.  